### PR TITLE
feat: add WASM support for browser and Cloudflare Worker targets

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,3 +44,16 @@ jobs:
 
       - name: Build
         run: make build
+
+  build_wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          override: true
+      - name: Build WASM
+        run: make build-wasm

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,3 +41,17 @@ jobs:
 
       - name: Lint
         run: make lint
+
+  lint_wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          components: clippy
+          override: true
+      - name: Lint WASM
+        run: make lint-wasm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,11 @@ members = [
     "tests/integration",
 ]
 
+[features]
+default = ["native"]
+native = ["tokio", "dotenv", "tracing-subscriber"]
+wasm = ["async-lock", "futures-timer", "web-time", "tracing-web", "tracing-subscriber", "getrandom"]
+
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -25,20 +30,30 @@ tracing = { workspace = true }
 rand = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true }
-tokio = { workspace = true }
 thiserror = { workspace = true }
 hmac = { workspace = true }
 sha2 = { workspace = true }
 urlencoding = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 pretty-simple-display = { workspace = true }
-dotenv = { workspace = true }
 chrono = { workspace = true }
-tracing-subscriber = { workspace = true }
 serde_with = { workspace = true }
+async-lock = { version = "3.4", optional = true }
+futures-timer = { version = "3.0", optional = true }
+
+# Native-only dependencies
+tokio = { workspace = true, optional = true }
+dotenv = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, optional = true }
+
+# WASM-only dependencies
+web-time = { version = "1.1", optional = true }
+tracing-web = { version = "0.1", optional = true }
+getrandom = { version = "0.3", features = ["wasm_js"], optional = true }
 
 [dev-dependencies]
 mockito = "1.7"
+tokio = { workspace = true }
 
 [workspace.dependencies]
 deribit-http = { path = "." }

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,11 @@ build:
 release:
 	cargo build --release
 
+# Build for WASM target
+.PHONY: build-wasm
+build-wasm:
+	cargo build --target wasm32-unknown-unknown --features wasm --no-default-features
+
 # Run unit tests
 .PHONY: test
 test:
@@ -44,8 +49,13 @@ lint:
 	cargo clippy --all-targets --all-features --workspace  -- -D warnings
 
 .PHONY: lint-fix
-lint-fix: 
+lint-fix:
 	cargo clippy --fix --all-targets --all-features --allow-dirty --allow-staged --workspace -- -D warnings
+
+# Run Clippy for WASM target
+.PHONY: lint-wasm
+lint-wasm:
+	cargo clippy --target wasm32-unknown-unknown --features wasm --no-default-features -- -D warnings
 
 # Clean the project
 .PHONY: clean

--- a/examples/cloudflare-worker/.cargo/config.toml
+++ b/examples/cloudflare-worker/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/examples/cloudflare-worker/Cargo.toml
+++ b/examples/cloudflare-worker/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "deribit-worker-example"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+deribit-http = { path = "../..", default-features = false, features = ["wasm"] }
+worker = "0.5"
+serde_json = "1.0"
+getrandom = { version = "0.3", features = ["wasm_js"] }
+
+# This makes the package standalone (not part of parent workspace)
+[workspace]

--- a/examples/cloudflare-worker/src/lib.rs
+++ b/examples/cloudflare-worker/src/lib.rs
@@ -1,0 +1,97 @@
+//! Cloudflare Worker example using deribit-http with WASM
+//!
+//! This example demonstrates how to use the deribit-http crate in a
+//! Cloudflare Worker environment to fetch public market data.
+//!
+//! ## Running locally
+//!
+//! ```bash
+//! npx wrangler dev
+//! ```
+//!
+//! ## Building
+//!
+//! ```bash
+//! npx wrangler build
+//! ```
+
+use deribit_http::prelude::{DeribitHttpClient, HttpConfig, setup_logger};
+use worker::*;
+
+#[event(fetch)]
+async fn fetch(req: Request, _env: Env, _ctx: Context) -> Result<Response> {
+    // Set up logging for WASM (routes to console.log)
+    setup_logger();
+
+    let url = req.url()?;
+    let path = url.path();
+
+    match path {
+        "/" => handle_root().await,
+        "/currencies" => handle_currencies().await,
+        "/ticker" => handle_ticker(&url).await,
+        _ => Response::error("Not Found", 404),
+    }
+}
+
+async fn handle_root() -> Result<Response> {
+    let html = r#"
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Deribit HTTP Worker Example</title>
+</head>
+<body>
+    <h1>Deribit HTTP Worker Example</h1>
+    <p>Available endpoints:</p>
+    <ul>
+        <li><a href="/currencies">/currencies</a> - List available currencies</li>
+        <li><a href="/ticker?instrument=BTC-PERPETUAL">/ticker?instrument=BTC-PERPETUAL</a> - Get ticker for an instrument</li>
+    </ul>
+</body>
+</html>
+    "#;
+    Response::from_html(html)
+}
+
+async fn handle_currencies() -> Result<Response> {
+    // Create client with default testnet configuration
+    let config = HttpConfig::default();
+    let client = DeribitHttpClient::with_config(config);
+
+    match client.get_currencies().await {
+        Ok(currencies) => {
+            let json = serde_json::to_string_pretty(&currencies)
+                .map_err(|e| Error::RustError(e.to_string()))?;
+            Response::ok(json).map(|r| r.with_headers(json_headers()))
+        }
+        Err(e) => Response::error(format!("Failed to fetch currencies: {}", e), 500),
+    }
+}
+
+async fn handle_ticker(url: &Url) -> Result<Response> {
+    let instrument = url
+        .query_pairs()
+        .find(|(k, _)| k == "instrument")
+        .map(|(_, v)| v.to_string())
+        .unwrap_or_else(|| "BTC-PERPETUAL".to_string());
+
+    // Create client with default testnet configuration
+    let config = HttpConfig::default();
+    let client = DeribitHttpClient::with_config(config);
+
+    match client.get_ticker(&instrument).await {
+        Ok(ticker) => {
+            let json = serde_json::to_string_pretty(&ticker)
+                .map_err(|e| Error::RustError(e.to_string()))?;
+            Response::ok(json).map(|r| r.with_headers(json_headers()))
+        }
+        Err(e) => Response::error(format!("Failed to fetch ticker: {}", e), 500),
+    }
+}
+
+fn json_headers() -> Headers {
+    let mut headers = Headers::new();
+    headers.set("Content-Type", "application/json").ok();
+    headers
+}

--- a/examples/cloudflare-worker/wrangler.toml
+++ b/examples/cloudflare-worker/wrangler.toml
@@ -1,0 +1,6 @@
+name = "deribit-worker-example"
+main = "build/worker/shim.mjs"
+compatibility_date = "2024-01-01"
+
+[build]
+command = "cargo install -q worker-build && worker-build --release"

--- a/src/connection/http_connection.rs
+++ b/src/connection/http_connection.rs
@@ -17,9 +17,14 @@ pub struct HttpConnection {
 impl HttpConnection {
     /// Create a new HTTP connection
     pub fn new(config: HttpConfig) -> Result<Self, HttpError> {
-        let client = Client::builder()
+        let builder = Client::builder();
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let builder = builder
             .timeout(config.timeout)
-            .user_agent(&config.user_agent)
+            .user_agent(&config.user_agent);
+
+        let client = builder
             .build()
             .map_err(|e| HttpError::NetworkError(e.to_string()))?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,12 @@ pub mod model;
 pub mod prelude;
 pub mod rate_limit;
 pub mod session;
+/// Cross-platform async sleep for native and WASM targets
+pub mod sleep_compat;
+/// Cross-platform Mutex re-export for native and WASM targets
+pub mod sync_compat;
+/// Cross-platform time utilities for native and WASM targets
+pub mod time_compat;
 
 // Constants
 /// Application constants and configuration

--- a/src/rate_limit.rs
+++ b/src/rate_limit.rs
@@ -4,11 +4,12 @@
 //! It implements a token bucket algorithm with different limits for different
 //! endpoint categories.
 
+use crate::time_compat::Instant;
+use crate::sleep_compat::sleep;
+use crate::sync_compat::Mutex;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
-use tokio::sync::Mutex;
-use tokio::time::sleep;
+use std::time::Duration;
 
 /// Rate limiter for different endpoint categories
 #[derive(Debug, Clone)]
@@ -187,10 +188,10 @@ pub fn categorize_endpoint(endpoint: &str) -> RateLimitCategory {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
-    use tokio::time::{Duration, sleep};
+    use crate::sleep_compat::sleep;
 
     #[tokio::test]
     async fn test_token_bucket_basic() {

--- a/src/session/http_session.rs
+++ b/src/session/http_session.rs
@@ -2,8 +2,8 @@
 
 use crate::config::HttpConfig;
 use crate::model::types::AuthToken;
+use crate::sync_compat::Mutex;
 use std::sync::Arc;
-use tokio::sync::Mutex;
 
 /// HTTP session manager
 #[derive(Debug, Clone)]

--- a/src/sleep_compat.rs
+++ b/src/sleep_compat.rs
@@ -1,0 +1,16 @@
+//! Cross-platform async sleep for native and WASM targets
+//!
+//! This module provides a unified `sleep` function that uses `tokio::time::sleep`
+//! on native targets and `futures_timer::Delay` on WASM targets.
+
+use std::time::Duration;
+
+#[cfg(feature = "native")]
+pub async fn sleep(duration: Duration) {
+    tokio::time::sleep(duration).await;
+}
+
+#[cfg(not(feature = "native"))]
+pub async fn sleep(duration: Duration) {
+    futures_timer::Delay::new(duration).await;
+}

--- a/src/sync_compat.rs
+++ b/src/sync_compat.rs
@@ -1,0 +1,10 @@
+//! Cross-platform Mutex re-export for native and WASM targets
+//!
+//! This module provides a unified `Mutex` type that uses `tokio::sync::Mutex`
+//! on native targets and `async_lock::Mutex` on WASM targets.
+
+#[cfg(feature = "native")]
+pub use tokio::sync::Mutex;
+
+#[cfg(not(feature = "native"))]
+pub use async_lock::Mutex;

--- a/src/time_compat.rs
+++ b/src/time_compat.rs
@@ -1,0 +1,10 @@
+//! Cross-platform time utilities for native and WASM targets
+//!
+//! This module provides a unified `Instant` type that works across
+//! both native (std::time::Instant) and WASM (web_time::Instant) targets.
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use std::time::Instant;
+
+#[cfg(target_arch = "wasm32")]
+pub use web_time::Instant;


### PR DESCRIPTION
> [!IMPORTANT]
> This PR depends on #4. Please merge #4 first — once merged, this PR will automatically show only the WASM-specific changes.

## Summary

Follow-up to the discussion in https://github.com/joaquinbejar/deribit-http/pull/3#issuecomment-3869776920. The refactoring was extracted into #4 and this PR adds WASM support on top of those changes.

### WASM Support
- Add `wasm` feature flag with conditional dependencies (`web-time`, `tracing-web`, `getrandom`)
- Replace `tokio::sync::Mutex` with `async_lock::Mutex` for cross-platform support
- Replace `tokio::time::sleep` with `futures_timer::Delay`
- Add `time_compat` module for cross-platform `Instant` (std vs web-time)
- Add `#[cfg]` guards for native-only code (timeout, user_agent, env vars)
- Add WASM-specific implementations for `ApiCredentials`

### Cross-Platform Logging
- Add WASM logging using `tracing-web` to route logs to browser/Worker console

### CI
- Add WASM build and lint jobs to CI pipeline

### Example
- Include Cloudflare Worker example demonstrating WASM usage

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` passes
- [x] `cargo test --lib` — all 22 tests pass
- [x] `cargo test --test '*'` — all 459 integration tests pass
- [x] `cargo check --target wasm32-unknown-unknown --no-default-features --features wasm` compiles
- [x] Cloudflare Worker example compiles for WASM target