### PR TITLE
M1 #8: Implement public/get_mark_price_history endpoint

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -241,7 +241,7 @@ impl AuthManager {
 
     /// Generate nonce for API key authentication
     pub fn generate_nonce() -> String {
-        use rand::Rng;
+        use rand::RngExt;
         let mut rng = rand::rng();
         let chars: String = (0..16)
             .map(|_| {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -84,6 +84,8 @@ pub mod endpoints {
         "/public/get_last_trades_by_instrument_and_time";
     /// Get order book by instrument ID
     pub const GET_ORDER_BOOK_BY_INSTRUMENT_ID: &str = "/public/get_order_book_by_instrument_id";
+    /// Get mark price history
+    pub const GET_MARK_PRICE_HISTORY: &str = "/public/get_mark_price_history";
 
     // Private trading endpoints
     /// Place a buy order

--- a/src/endpoints/public.rs
+++ b/src/endpoints/public.rs
@@ -17,7 +17,7 @@ use crate::model::other::{OptionInstrument, OptionInstrumentPair};
 use crate::model::response::api_response::ApiResponse;
 use crate::model::response::other::{
     AprHistoryResponse, ContractSizeResponse, DeliveryPricesResponse, ExpirationsResponse,
-    SettlementsResponse, StatusResponse, TestResponse,
+    MarkPriceHistoryPoint, SettlementsResponse, StatusResponse, TestResponse,
 };
 use crate::model::ticker::TickerData;
 use crate::model::trade::{Liquidity, Trade};
@@ -1230,6 +1230,94 @@ impl DeribitHttpClient {
 
         api_response.result.ok_or_else(|| {
             HttpError::InvalidResponse("No historical volatility data in response".to_string())
+        })
+    }
+
+    /// Get mark price history
+    ///
+    /// Retrieves 5-minute historical mark price data for an instrument.
+    /// Mark prices are used for margin calculations and position valuations.
+    ///
+    /// **Note**: Currently, mark price history is available only for a subset of options
+    /// that participate in volatility index calculations. All other instruments,
+    /// including futures and perpetuals, will return an empty list.
+    ///
+    /// # Arguments
+    ///
+    /// * `instrument_name` - Unique instrument identifier (e.g., "BTC-25JUN21-50000-C")
+    /// * `start_timestamp` - The earliest timestamp to return results from (milliseconds since Unix epoch)
+    /// * `end_timestamp` - The most recent timestamp to return results from (milliseconds since Unix epoch)
+    ///
+    /// # Returns
+    ///
+    /// Returns a vector of `MarkPriceHistoryPoint` containing timestamp and mark price pairs.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or the response cannot be parsed.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let history = client.get_mark_price_history(
+    /// //     "BTC-25JUN21-50000-C",
+    /// //     1609376800000,
+    /// //     1609376810000
+    /// // ).await?;
+    /// // for point in history {
+    /// //     println!("Time: {}, Mark Price: {}", point.timestamp, point.mark_price);
+    /// // }
+    /// ```
+    pub async fn get_mark_price_history(
+        &self,
+        instrument_name: &str,
+        start_timestamp: u64,
+        end_timestamp: u64,
+    ) -> Result<Vec<MarkPriceHistoryPoint>, HttpError> {
+        let url = format!(
+            "{}{}?instrument_name={}&start_timestamp={}&end_timestamp={}",
+            self.base_url(),
+            GET_MARK_PRICE_HISTORY,
+            urlencoding::encode(instrument_name),
+            start_timestamp,
+            end_timestamp
+        );
+
+        let response = self
+            .http_client()
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| HttpError::NetworkError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get mark price history failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<Vec<MarkPriceHistoryPoint>> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response.result.ok_or_else(|| {
+            HttpError::InvalidResponse("No mark price history data in response".to_string())
         })
     }
 

--- a/src/model/response/other.rs
+++ b/src/model/response/other.rs
@@ -249,6 +249,34 @@ pub struct AccountSummaryResponse {
     pub summaries: Vec<AccountResult>,
 }
 
+/// Mark price history data point
+///
+/// Represents a single data point in mark price history.
+/// The API returns data as `[timestamp_ms, mark_price]` arrays.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(from = "(u64, f64)", into = "(u64, f64)")]
+pub struct MarkPriceHistoryPoint {
+    /// Timestamp in milliseconds since Unix epoch
+    pub timestamp: u64,
+    /// Mark price value
+    pub mark_price: f64,
+}
+
+impl From<(u64, f64)> for MarkPriceHistoryPoint {
+    fn from((timestamp, mark_price): (u64, f64)) -> Self {
+        Self {
+            timestamp,
+            mark_price,
+        }
+    }
+}
+
+impl From<MarkPriceHistoryPoint> for (u64, f64) {
+    fn from(point: MarkPriceHistoryPoint) -> Self {
+        (point.timestamp, point.mark_price)
+    }
+}
+
 /// Account summary information
 #[skip_serializing_none]
 #[derive(DebugPretty, DisplaySimple, Clone, Serialize, Deserialize)]

--- a/tests/unit/response_other_tests.rs
+++ b/tests/unit/response_other_tests.rs
@@ -549,3 +549,106 @@ fn test_account_limits_serialization() {
     assert!(serialized.contains("non_matching_engine"));
     assert!(serialized.contains("matching_engine"));
 }
+
+// Tests for MarkPriceHistoryPoint
+#[test]
+fn test_mark_price_history_point_creation() {
+    let point = MarkPriceHistoryPoint {
+        timestamp: 1608142381229,
+        mark_price: 0.5165791606037885,
+    };
+
+    assert_eq!(point.timestamp, 1608142381229);
+    assert!((point.mark_price - 0.5165791606037885).abs() < f64::EPSILON);
+}
+
+#[test]
+fn test_mark_price_history_point_from_tuple() {
+    let tuple: (u64, f64) = (1608142381229, 0.5165791606037885);
+    let point = MarkPriceHistoryPoint::from(tuple);
+
+    assert_eq!(point.timestamp, 1608142381229);
+    assert!((point.mark_price - 0.5165791606037885).abs() < f64::EPSILON);
+}
+
+#[test]
+fn test_mark_price_history_point_into_tuple() {
+    let point = MarkPriceHistoryPoint {
+        timestamp: 1608142381229,
+        mark_price: 0.5165791606037885,
+    };
+    let tuple: (u64, f64) = point.into();
+
+    assert_eq!(tuple.0, 1608142381229);
+    assert!((tuple.1 - 0.5165791606037885).abs() < f64::EPSILON);
+}
+
+#[test]
+fn test_mark_price_history_point_deserialization_from_array() {
+    let json = "[1608142381229, 0.5165791606037885]";
+    let point: MarkPriceHistoryPoint = serde_json::from_str(json).unwrap();
+
+    assert_eq!(point.timestamp, 1608142381229);
+    assert!((point.mark_price - 0.5165791606037885).abs() < f64::EPSILON);
+}
+
+#[test]
+fn test_mark_price_history_point_serialization_to_array() {
+    let point = MarkPriceHistoryPoint {
+        timestamp: 1608142381229,
+        mark_price: 0.5165791606037885,
+    };
+    let serialized = serde_json::to_string(&point).unwrap();
+
+    assert!(serialized.contains("1608142381229"));
+    assert!(serialized.contains("0.5165791606037885"));
+}
+
+#[test]
+fn test_mark_price_history_point_vec_deserialization() {
+    let json = r#"[
+        [1608142381229, 0.5165791606037885],
+        [1608142380231, 0.5165737855432504],
+        [1608142379227, 0.5165768236356326]
+    ]"#;
+    let points: Vec<MarkPriceHistoryPoint> = serde_json::from_str(json).unwrap();
+
+    assert_eq!(points.len(), 3);
+    assert_eq!(points[0].timestamp, 1608142381229);
+    assert_eq!(points[1].timestamp, 1608142380231);
+    assert_eq!(points[2].timestamp, 1608142379227);
+}
+
+#[test]
+fn test_mark_price_history_point_empty_vec_deserialization() {
+    let json = "[]";
+    let points: Vec<MarkPriceHistoryPoint> = serde_json::from_str(json).unwrap();
+
+    assert!(points.is_empty());
+}
+
+#[test]
+fn test_mark_price_history_point_clone() {
+    let point = MarkPriceHistoryPoint {
+        timestamp: 1608142381229,
+        mark_price: 0.5165791606037885,
+    };
+    let cloned = point.clone();
+
+    assert_eq!(point.timestamp, cloned.timestamp);
+    assert!((point.mark_price - cloned.mark_price).abs() < f64::EPSILON);
+}
+
+#[test]
+fn test_mark_price_history_point_equality() {
+    let point1 = MarkPriceHistoryPoint {
+        timestamp: 1608142381229,
+        mark_price: 0.5165791606037885,
+    };
+    let point2 = MarkPriceHistoryPoint {
+        timestamp: 1608142381229,
+        mark_price: 0.5165791606037885,
+    };
+
+    assert_eq!(point1, point2);
+}


### PR DESCRIPTION
## Summary

Implement the `public/get_mark_price_history` endpoint for retrieving 5-minute historical mark price data for options instruments.

## Changes

- Add `GET_MARK_PRICE_HISTORY` constant in `src/constants.rs`
- Add `MarkPriceHistoryPoint` struct with custom serde for tuple `[timestamp, price]` format
- Add `get_mark_price_history()` method on `DeribitHttpClient`
- Add 9 unit tests for the new model
- Fix `rand` 0.10 API change (use `RngExt` for `random_range`)

## API Details

**Endpoint**: `public/get_mark_price_history`

**Parameters**:
- `instrument_name` - Unique instrument identifier
- `start_timestamp` - Start time in milliseconds since Unix epoch
- `end_timestamp` - End time in milliseconds since Unix epoch

**Note**: Mark price history is only available for options participating in volatility index calculations.

## Testing

- [x] Unit tests added/updated (9 new tests)
- [ ] Integration tests added/updated (API may return empty for non-option instruments)
- [ ] Benchmark tests added/updated (if applicable)
- [x] Manual testing performed (`cargo test --all-features`)

## Checklist

- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] No `.unwrap()`, `.expect()`, or panics in library code
- [x] HTTP error handling implemented
- [x] Minimal dependencies — no unnecessary crates added

Closes #8
