### PR TITLE
M1 #9: Implement public/get_supported_index_names endpoint

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -86,6 +86,8 @@ pub mod endpoints {
     pub const GET_ORDER_BOOK_BY_INSTRUMENT_ID: &str = "/public/get_order_book_by_instrument_id";
     /// Get mark price history
     pub const GET_MARK_PRICE_HISTORY: &str = "/public/get_mark_price_history";
+    /// Get supported index names
+    pub const GET_SUPPORTED_INDEX_NAMES: &str = "/public/get_supported_index_names";
 
     // Private trading endpoints
     /// Place a buy order

--- a/src/endpoints/public.rs
+++ b/src/endpoints/public.rs
@@ -17,7 +17,7 @@ use crate::model::other::{OptionInstrument, OptionInstrumentPair};
 use crate::model::response::api_response::ApiResponse;
 use crate::model::response::other::{
     AprHistoryResponse, ContractSizeResponse, DeliveryPricesResponse, ExpirationsResponse,
-    MarkPriceHistoryPoint, SettlementsResponse, StatusResponse, TestResponse,
+    IndexNameInfo, MarkPriceHistoryPoint, SettlementsResponse, StatusResponse, TestResponse,
 };
 use crate::model::ticker::TickerData;
 use crate::model::trade::{Liquidity, Trade};
@@ -1318,6 +1318,170 @@ impl DeribitHttpClient {
 
         api_response.result.ok_or_else(|| {
             HttpError::InvalidResponse("No mark price history data in response".to_string())
+        })
+    }
+
+    /// Get supported index names
+    ///
+    /// Retrieves the identifiers (names) of all supported price indexes.
+    /// Price indexes are reference prices used for mark price calculations,
+    /// settlement, and other market operations.
+    ///
+    /// # Arguments
+    ///
+    /// * `index_type` - Optional filter by index type: "all", "spot", or "derivative"
+    ///
+    /// # Returns
+    ///
+    /// Returns a vector of index name strings (e.g., "btc_eth", "btc_usdc").
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or the response cannot be parsed.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // Get all index names
+    /// // let names = client.get_supported_index_names(None).await?;
+    /// // for name in names {
+    /// //     println!("Index: {}", name);
+    /// // }
+    /// //
+    /// // Get only spot indexes
+    /// // let spot_names = client.get_supported_index_names(Some("spot")).await?;
+    /// ```
+    pub async fn get_supported_index_names(
+        &self,
+        index_type: Option<&str>,
+    ) -> Result<Vec<String>, HttpError> {
+        let url = match index_type {
+            Some(t) => format!(
+                "{}{}?type={}",
+                self.base_url(),
+                GET_SUPPORTED_INDEX_NAMES,
+                urlencoding::encode(t)
+            ),
+            None => format!("{}{}", self.base_url(), GET_SUPPORTED_INDEX_NAMES),
+        };
+
+        let response = self
+            .http_client()
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| HttpError::NetworkError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get supported index names failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<Vec<String>> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response.result.ok_or_else(|| {
+            HttpError::InvalidResponse("No supported index names in response".to_string())
+        })
+    }
+
+    /// Get supported index names with extended information
+    ///
+    /// Retrieves the identifiers (names) of all supported price indexes
+    /// along with combo trading availability flags.
+    ///
+    /// # Arguments
+    ///
+    /// * `index_type` - Optional filter by index type: "all", "spot", or "derivative"
+    ///
+    /// # Returns
+    ///
+    /// Returns a vector of `IndexNameInfo` containing index names and
+    /// optional combo trading flags.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or the response cannot be parsed.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let indexes = client.get_supported_index_names_extended(None).await?;
+    /// // for idx in indexes {
+    /// //     println!("Index: {}, Future combo: {:?}", idx.name, idx.future_combo_enabled);
+    /// // }
+    /// ```
+    pub async fn get_supported_index_names_extended(
+        &self,
+        index_type: Option<&str>,
+    ) -> Result<Vec<IndexNameInfo>, HttpError> {
+        let url = match index_type {
+            Some(t) => format!(
+                "{}{}?type={}&extended=true",
+                self.base_url(),
+                GET_SUPPORTED_INDEX_NAMES,
+                urlencoding::encode(t)
+            ),
+            None => format!(
+                "{}{}?extended=true",
+                self.base_url(),
+                GET_SUPPORTED_INDEX_NAMES
+            ),
+        };
+
+        let response = self
+            .http_client()
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| HttpError::NetworkError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get supported index names extended failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<Vec<IndexNameInfo>> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response.result.ok_or_else(|| {
+            HttpError::InvalidResponse("No supported index names in response".to_string())
         })
     }
 

--- a/src/model/response/other.rs
+++ b/src/model/response/other.rs
@@ -277,6 +277,21 @@ impl From<MarkPriceHistoryPoint> for (u64, f64) {
     }
 }
 
+/// Index name information with extended details
+///
+/// Represents an index with optional combo trading availability flags.
+/// Returned by `get_supported_index_names` when `extended=true`.
+#[skip_serializing_none]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct IndexNameInfo {
+    /// Index name identifier (e.g., "btc_eth", "btc_usdc")
+    pub name: String,
+    /// Whether future combo creation is enabled for this index
+    pub future_combo_enabled: Option<bool>,
+    /// Whether option combo creation is enabled for this index
+    pub option_combo_enabled: Option<bool>,
+}
+
 /// Account summary information
 #[skip_serializing_none]
 #[derive(DebugPretty, DisplaySimple, Clone, Serialize, Deserialize)]

--- a/tests/unit/response_other_tests.rs
+++ b/tests/unit/response_other_tests.rs
@@ -652,3 +652,136 @@ fn test_mark_price_history_point_equality() {
 
     assert_eq!(point1, point2);
 }
+
+// Tests for IndexNameInfo
+#[test]
+fn test_index_name_info_creation() {
+    let info = IndexNameInfo {
+        name: "btc_usdc".to_string(),
+        future_combo_enabled: Some(true),
+        option_combo_enabled: Some(false),
+    };
+
+    assert_eq!(info.name, "btc_usdc");
+    assert_eq!(info.future_combo_enabled, Some(true));
+    assert_eq!(info.option_combo_enabled, Some(false));
+}
+
+#[test]
+fn test_index_name_info_minimal() {
+    let info = IndexNameInfo {
+        name: "btc_eth".to_string(),
+        future_combo_enabled: None,
+        option_combo_enabled: None,
+    };
+
+    assert_eq!(info.name, "btc_eth");
+    assert!(info.future_combo_enabled.is_none());
+    assert!(info.option_combo_enabled.is_none());
+}
+
+#[test]
+fn test_index_name_info_serialization() {
+    let info = IndexNameInfo {
+        name: "eth_usdc".to_string(),
+        future_combo_enabled: Some(true),
+        option_combo_enabled: Some(true),
+    };
+
+    let serialized = serde_json::to_string(&info).unwrap();
+    assert!(serialized.contains("eth_usdc"));
+    assert!(serialized.contains("future_combo_enabled"));
+    assert!(serialized.contains("option_combo_enabled"));
+}
+
+#[test]
+fn test_index_name_info_serialization_skips_none() {
+    let info = IndexNameInfo {
+        name: "sol_usdc".to_string(),
+        future_combo_enabled: None,
+        option_combo_enabled: None,
+    };
+
+    let serialized = serde_json::to_string(&info).unwrap();
+    assert!(serialized.contains("sol_usdc"));
+    assert!(!serialized.contains("future_combo_enabled"));
+    assert!(!serialized.contains("option_combo_enabled"));
+}
+
+#[test]
+fn test_index_name_info_deserialization_full() {
+    let json = r#"{
+        "name": "btc_usdc",
+        "future_combo_enabled": true,
+        "option_combo_enabled": false
+    }"#;
+
+    let info: IndexNameInfo = serde_json::from_str(json).unwrap();
+    assert_eq!(info.name, "btc_usdc");
+    assert_eq!(info.future_combo_enabled, Some(true));
+    assert_eq!(info.option_combo_enabled, Some(false));
+}
+
+#[test]
+fn test_index_name_info_deserialization_minimal() {
+    let json = r#"{"name": "btc_eth"}"#;
+
+    let info: IndexNameInfo = serde_json::from_str(json).unwrap();
+    assert_eq!(info.name, "btc_eth");
+    assert!(info.future_combo_enabled.is_none());
+    assert!(info.option_combo_enabled.is_none());
+}
+
+#[test]
+fn test_index_name_info_vec_deserialization() {
+    let json = r#"[
+        {"name": "btc_eth", "future_combo_enabled": true, "option_combo_enabled": false},
+        {"name": "btc_usdc", "future_combo_enabled": false, "option_combo_enabled": true},
+        {"name": "eth_usdc"}
+    ]"#;
+
+    let infos: Vec<IndexNameInfo> = serde_json::from_str(json).unwrap();
+    assert_eq!(infos.len(), 3);
+    assert_eq!(infos[0].name, "btc_eth");
+    assert_eq!(infos[1].name, "btc_usdc");
+    assert_eq!(infos[2].name, "eth_usdc");
+    assert!(infos[2].future_combo_enabled.is_none());
+}
+
+#[test]
+fn test_index_name_info_clone() {
+    let info = IndexNameInfo {
+        name: "btc_usdc".to_string(),
+        future_combo_enabled: Some(true),
+        option_combo_enabled: Some(false),
+    };
+    let cloned = info.clone();
+
+    assert_eq!(info.name, cloned.name);
+    assert_eq!(info.future_combo_enabled, cloned.future_combo_enabled);
+    assert_eq!(info.option_combo_enabled, cloned.option_combo_enabled);
+}
+
+#[test]
+fn test_index_name_info_equality() {
+    let info1 = IndexNameInfo {
+        name: "btc_usdc".to_string(),
+        future_combo_enabled: Some(true),
+        option_combo_enabled: Some(false),
+    };
+    let info2 = IndexNameInfo {
+        name: "btc_usdc".to_string(),
+        future_combo_enabled: Some(true),
+        option_combo_enabled: Some(false),
+    };
+
+    assert_eq!(info1, info2);
+}
+
+#[test]
+fn test_index_name_info_empty_vec() {
+    let json = "[]";
+    let infos: Vec<IndexNameInfo> = serde_json::from_str(json).unwrap();
+
+    assert!(infos.is_empty());
+}


### PR DESCRIPTION
## Summary

Implement the `public/get_supported_index_names` endpoint to retrieve identifiers of all supported price indexes.

## Changes

### Constant (`src/constants.rs`)
- `GET_SUPPORTED_INDEX_NAMES` — endpoint path constant

### Model (`src/model/response/other.rs`)
- `IndexNameInfo` — struct for extended response with combo trading flags

### Methods (`src/endpoints/public.rs`)
- `get_supported_index_names()` — returns `Vec<String>` of index names
- `get_supported_index_names_extended()` — returns `Vec<IndexNameInfo>` with combo flags

## Testing

- [x] Unit tests added (10 tests for `IndexNameInfo`)
- [ ] Integration tests (optional - endpoint is public)
- [x] Manual testing performed (`make pre-push`)

## Checklist

- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] No `.unwrap()`, `.expect()`, or panics in library code
- [x] Minimal dependencies — no unnecessary crates added

Closes #9
