### PR TITLE
M1 #10: Implement public/get_trade_volumes endpoint

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -88,6 +88,8 @@ pub mod endpoints {
     pub const GET_MARK_PRICE_HISTORY: &str = "/public/get_mark_price_history";
     /// Get supported index names
     pub const GET_SUPPORTED_INDEX_NAMES: &str = "/public/get_supported_index_names";
+    /// Get trade volumes
+    pub const GET_TRADE_VOLUMES: &str = "/public/get_trade_volumes";
 
     // Private trading endpoints
     /// Place a buy order

--- a/src/endpoints/public.rs
+++ b/src/endpoints/public.rs
@@ -18,6 +18,7 @@ use crate::model::response::api_response::ApiResponse;
 use crate::model::response::other::{
     AprHistoryResponse, ContractSizeResponse, DeliveryPricesResponse, ExpirationsResponse,
     IndexNameInfo, MarkPriceHistoryPoint, SettlementsResponse, StatusResponse, TestResponse,
+    TradeVolume,
 };
 use crate::model::ticker::TickerData;
 use crate::model::trade::{Liquidity, Trade};
@@ -1483,6 +1484,81 @@ impl DeribitHttpClient {
         api_response.result.ok_or_else(|| {
             HttpError::InvalidResponse("No supported index names in response".to_string())
         })
+    }
+
+    /// Get trade volumes
+    ///
+    /// Retrieves aggregated 24-hour trade volumes for different instrument types
+    /// and currencies. Block trades and Block RFQ trades are included.
+    /// Position moves are not included.
+    ///
+    /// # Arguments
+    ///
+    /// * `extended` - If true, include 7-day and 30-day volumes
+    ///
+    /// # Returns
+    ///
+    /// Returns a vector of `TradeVolume` with volume data per currency.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or the response cannot be parsed.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // Get basic 24h volumes
+    /// // let volumes = client.get_trade_volumes(false).await?;
+    /// // for vol in volumes {
+    /// //     println!("{}: futures={}, calls={}", vol.currency, vol.futures_volume, vol.calls_volume);
+    /// // }
+    /// //
+    /// // Get extended volumes (7d, 30d)
+    /// // let extended = client.get_trade_volumes(true).await?;
+    /// ```
+    pub async fn get_trade_volumes(&self, extended: bool) -> Result<Vec<TradeVolume>, HttpError> {
+        let url = if extended {
+            format!("{}{}?extended=true", self.base_url(), GET_TRADE_VOLUMES)
+        } else {
+            format!("{}{}", self.base_url(), GET_TRADE_VOLUMES)
+        };
+
+        let response = self
+            .http_client()
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| HttpError::NetworkError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get trade volumes failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<Vec<TradeVolume>> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No trade volumes in response".to_string()))
     }
 
     /// Get funding chart data

--- a/src/model/response/other.rs
+++ b/src/model/response/other.rs
@@ -292,6 +292,41 @@ pub struct IndexNameInfo {
     pub option_combo_enabled: Option<bool>,
 }
 
+/// Aggregated trade volume by currency
+///
+/// Contains 24-hour trade volumes for different instrument types.
+/// When `extended=true`, also includes 7-day and 30-day volumes.
+#[skip_serializing_none]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TradeVolume {
+    /// Currency (e.g., "BTC", "ETH", "USDC")
+    pub currency: String,
+    /// Total 24h trade volume for call options
+    pub calls_volume: f64,
+    /// Total 24h trade volume for put options
+    pub puts_volume: f64,
+    /// Total 24h trade volume for futures
+    pub futures_volume: f64,
+    /// Total 24h trade volume for spot
+    pub spot_volume: f64,
+    /// Total 7d trade volume for call options (extended only)
+    pub calls_volume_7d: Option<f64>,
+    /// Total 7d trade volume for put options (extended only)
+    pub puts_volume_7d: Option<f64>,
+    /// Total 7d trade volume for futures (extended only)
+    pub futures_volume_7d: Option<f64>,
+    /// Total 7d trade volume for spot (extended only)
+    pub spot_volume_7d: Option<f64>,
+    /// Total 30d trade volume for call options (extended only)
+    pub calls_volume_30d: Option<f64>,
+    /// Total 30d trade volume for put options (extended only)
+    pub puts_volume_30d: Option<f64>,
+    /// Total 30d trade volume for futures (extended only)
+    pub futures_volume_30d: Option<f64>,
+    /// Total 30d trade volume for spot (extended only)
+    pub spot_volume_30d: Option<f64>,
+}
+
 /// Account summary information
 #[skip_serializing_none]
 #[derive(DebugPretty, DisplaySimple, Clone, Serialize, Deserialize)]

--- a/tests/unit/response_other_tests.rs
+++ b/tests/unit/response_other_tests.rs
@@ -785,3 +785,209 @@ fn test_index_name_info_empty_vec() {
 
     assert!(infos.is_empty());
 }
+
+// Tests for TradeVolume
+#[test]
+fn test_trade_volume_basic_creation() {
+    let vol = TradeVolume {
+        currency: "BTC".to_string(),
+        calls_volume: 145.0,
+        puts_volume: 48.0,
+        futures_volume: 6.25578452,
+        spot_volume: 11.1,
+        calls_volume_7d: None,
+        puts_volume_7d: None,
+        futures_volume_7d: None,
+        spot_volume_7d: None,
+        calls_volume_30d: None,
+        puts_volume_30d: None,
+        futures_volume_30d: None,
+        spot_volume_30d: None,
+    };
+
+    assert_eq!(vol.currency, "BTC");
+    assert!((vol.calls_volume - 145.0).abs() < f64::EPSILON);
+    assert!((vol.puts_volume - 48.0).abs() < f64::EPSILON);
+    assert!((vol.futures_volume - 6.25578452).abs() < 1e-8);
+    assert!((vol.spot_volume - 11.1).abs() < f64::EPSILON);
+}
+
+#[test]
+fn test_trade_volume_extended_creation() {
+    let vol = TradeVolume {
+        currency: "ETH".to_string(),
+        calls_volume: 37.4,
+        puts_volume: 122.65,
+        futures_volume: 374.392173,
+        spot_volume: 57.7,
+        calls_volume_7d: Some(75.6),
+        puts_volume_7d: Some(356.9),
+        futures_volume_7d: Some(213.8841),
+        spot_volume_7d: Some(64.8),
+        calls_volume_30d: Some(547.3),
+        puts_volume_30d: Some(785.5),
+        futures_volume_30d: Some(998.2128),
+        spot_volume_30d: Some(310.5),
+    };
+
+    assert_eq!(vol.currency, "ETH");
+    assert_eq!(vol.calls_volume_7d, Some(75.6));
+    assert_eq!(vol.puts_volume_30d, Some(785.5));
+}
+
+#[test]
+fn test_trade_volume_deserialization_basic() {
+    let json = r#"{
+        "currency": "BTC",
+        "calls_volume": 145,
+        "puts_volume": 48,
+        "futures_volume": 6.25578452,
+        "spot_volume": 11.1
+    }"#;
+
+    let vol: TradeVolume = serde_json::from_str(json).unwrap();
+    assert_eq!(vol.currency, "BTC");
+    assert!((vol.calls_volume - 145.0).abs() < f64::EPSILON);
+    assert!(vol.calls_volume_7d.is_none());
+    assert!(vol.futures_volume_30d.is_none());
+}
+
+#[test]
+fn test_trade_volume_deserialization_extended() {
+    let json = r#"{
+        "currency": "ETH",
+        "calls_volume": 37.4,
+        "puts_volume": 122.65,
+        "futures_volume": 374.392173,
+        "spot_volume": 57.7,
+        "calls_volume_7d": 75.6,
+        "puts_volume_7d": 356.9,
+        "futures_volume_7d": 213.8841,
+        "spot_volume_7d": 64.8,
+        "calls_volume_30d": 547.3,
+        "puts_volume_30d": 785.5,
+        "futures_volume_30d": 998.2128,
+        "spot_volume_30d": 310.5
+    }"#;
+
+    let vol: TradeVolume = serde_json::from_str(json).unwrap();
+    assert_eq!(vol.currency, "ETH");
+    assert_eq!(vol.calls_volume_7d, Some(75.6));
+    assert_eq!(vol.futures_volume_30d, Some(998.2128));
+}
+
+#[test]
+fn test_trade_volume_serialization_skips_none() {
+    let vol = TradeVolume {
+        currency: "USDC".to_string(),
+        calls_volume: 10.0,
+        puts_volume: 20.0,
+        futures_volume: 30.0,
+        spot_volume: 40.0,
+        calls_volume_7d: None,
+        puts_volume_7d: None,
+        futures_volume_7d: None,
+        spot_volume_7d: None,
+        calls_volume_30d: None,
+        puts_volume_30d: None,
+        futures_volume_30d: None,
+        spot_volume_30d: None,
+    };
+
+    let serialized = serde_json::to_string(&vol).unwrap();
+    assert!(serialized.contains("USDC"));
+    assert!(!serialized.contains("calls_volume_7d"));
+    assert!(!serialized.contains("futures_volume_30d"));
+}
+
+#[test]
+fn test_trade_volume_vec_deserialization() {
+    let json = r#"[
+        {
+            "currency": "BTC",
+            "calls_volume": 145,
+            "puts_volume": 48,
+            "futures_volume": 6.25578452,
+            "spot_volume": 11.1
+        },
+        {
+            "currency": "ETH",
+            "calls_volume": 37.4,
+            "puts_volume": 122.65,
+            "futures_volume": 374.392173,
+            "spot_volume": 57.7
+        }
+    ]"#;
+
+    let volumes: Vec<TradeVolume> = serde_json::from_str(json).unwrap();
+    assert_eq!(volumes.len(), 2);
+    assert_eq!(volumes[0].currency, "BTC");
+    assert_eq!(volumes[1].currency, "ETH");
+}
+
+#[test]
+fn test_trade_volume_empty_vec() {
+    let json = "[]";
+    let volumes: Vec<TradeVolume> = serde_json::from_str(json).unwrap();
+
+    assert!(volumes.is_empty());
+}
+
+#[test]
+fn test_trade_volume_clone() {
+    let vol = TradeVolume {
+        currency: "BTC".to_string(),
+        calls_volume: 145.0,
+        puts_volume: 48.0,
+        futures_volume: 6.25578452,
+        spot_volume: 11.1,
+        calls_volume_7d: Some(75.6),
+        puts_volume_7d: None,
+        futures_volume_7d: None,
+        spot_volume_7d: None,
+        calls_volume_30d: None,
+        puts_volume_30d: None,
+        futures_volume_30d: None,
+        spot_volume_30d: None,
+    };
+    let cloned = vol.clone();
+
+    assert_eq!(vol.currency, cloned.currency);
+    assert_eq!(vol.calls_volume_7d, cloned.calls_volume_7d);
+}
+
+#[test]
+fn test_trade_volume_equality() {
+    let vol1 = TradeVolume {
+        currency: "BTC".to_string(),
+        calls_volume: 145.0,
+        puts_volume: 48.0,
+        futures_volume: 6.25578452,
+        spot_volume: 11.1,
+        calls_volume_7d: None,
+        puts_volume_7d: None,
+        futures_volume_7d: None,
+        spot_volume_7d: None,
+        calls_volume_30d: None,
+        puts_volume_30d: None,
+        futures_volume_30d: None,
+        spot_volume_30d: None,
+    };
+    let vol2 = TradeVolume {
+        currency: "BTC".to_string(),
+        calls_volume: 145.0,
+        puts_volume: 48.0,
+        futures_volume: 6.25578452,
+        spot_volume: 11.1,
+        calls_volume_7d: None,
+        puts_volume_7d: None,
+        futures_volume_7d: None,
+        spot_volume_7d: None,
+        calls_volume_30d: None,
+        puts_volume_30d: None,
+        futures_volume_30d: None,
+        spot_volume_30d: None,
+    };
+
+    assert_eq!(vol1, vol2);
+}


### PR DESCRIPTION
## Summary

Implement the `public/get_trade_volumes` endpoint to retrieve aggregated 24-hour trade volumes by currency.

## Changes

### Constant (`src/constants.rs`)
- `GET_TRADE_VOLUMES` — endpoint path constant

### Model (`src/model/response/other.rs`)
- `TradeVolume` — struct with 12 fields (24h, 7d, 30d volumes for calls, puts, futures, spot)

### Method (`src/endpoints/public.rs`)
- `get_trade_volumes(extended: bool)` — returns `Vec<TradeVolume>`

## Testing

- [x] Unit tests added (9 tests for `TradeVolume`)
- [x] Manual testing performed (`make pre-push`)

## Checklist

- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] No `.unwrap()`, `.expect()`, or panics in library code
- [x] Minimal dependencies — no unnecessary crates added

Closes #10
