### PR TITLE
M1 #11: Implement public/get_volatility_index_data endpoint

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -90,6 +90,8 @@ pub mod endpoints {
     pub const GET_SUPPORTED_INDEX_NAMES: &str = "/public/get_supported_index_names";
     /// Get trade volumes
     pub const GET_TRADE_VOLUMES: &str = "/public/get_trade_volumes";
+    /// Get volatility index data
+    pub const GET_VOLATILITY_INDEX_DATA: &str = "/public/get_volatility_index_data";
 
     // Private trading endpoints
     /// Place a buy order

--- a/src/endpoints/public.rs
+++ b/src/endpoints/public.rs
@@ -18,7 +18,7 @@ use crate::model::response::api_response::ApiResponse;
 use crate::model::response::other::{
     AprHistoryResponse, ContractSizeResponse, DeliveryPricesResponse, ExpirationsResponse,
     IndexNameInfo, MarkPriceHistoryPoint, SettlementsResponse, StatusResponse, TestResponse,
-    TradeVolume,
+    TradeVolume, VolatilityIndexData,
 };
 use crate::model::ticker::TickerData;
 use crate::model::trade::{Liquidity, Trade};
@@ -1559,6 +1559,95 @@ impl DeribitHttpClient {
         api_response
             .result
             .ok_or_else(|| HttpError::InvalidResponse("No trade volumes in response".to_string()))
+    }
+
+    /// Get volatility index data
+    ///
+    /// Retrieves volatility index (VIX) chart data formatted as OHLC candles.
+    /// Useful for risk assessment and trading strategies.
+    ///
+    /// # Arguments
+    ///
+    /// * `currency` - Currency symbol (e.g., "BTC", "ETH")
+    /// * `start_timestamp` - Start timestamp in milliseconds since UNIX epoch
+    /// * `end_timestamp` - End timestamp in milliseconds since UNIX epoch
+    /// * `resolution` - Candle interval ("1", "60", "3600", "43200", "1D")
+    ///
+    /// # Returns
+    ///
+    /// Returns `VolatilityIndexData` with candles and optional continuation token.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or the response cannot be parsed.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // Get 1-hour VIX candles for BTC
+    /// // let vix_data = client.get_volatility_index_data(
+    /// //     "BTC",
+    /// //     1599373800000,
+    /// //     1599376800000,
+    /// //     "60"
+    /// // ).await?;
+    /// // for candle in &vix_data.data {
+    /// //     println!("ts={}, close={}", candle.timestamp, candle.close);
+    /// // }
+    /// ```
+    pub async fn get_volatility_index_data(
+        &self,
+        currency: &str,
+        start_timestamp: u64,
+        end_timestamp: u64,
+        resolution: &str,
+    ) -> Result<VolatilityIndexData, HttpError> {
+        let url = format!(
+            "{}{}?currency={}&start_timestamp={}&end_timestamp={}&resolution={}",
+            self.base_url(),
+            GET_VOLATILITY_INDEX_DATA,
+            currency,
+            start_timestamp,
+            end_timestamp,
+            resolution
+        );
+
+        let response = self
+            .http_client()
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| HttpError::NetworkError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get volatility index data failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<VolatilityIndexData> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response.result.ok_or_else(|| {
+            HttpError::InvalidResponse("No volatility index data in response".to_string())
+        })
     }
 
     /// Get funding chart data

--- a/src/model/response/other.rs
+++ b/src/model/response/other.rs
@@ -327,6 +327,80 @@ pub struct TradeVolume {
     pub spot_volume_30d: Option<f64>,
 }
 
+/// A single volatility index candle
+///
+/// Represents OHLC data for a volatility index at a specific timestamp.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VolatilityIndexCandle {
+    /// Timestamp in milliseconds since UNIX epoch
+    pub timestamp: u64,
+    /// Open value
+    pub open: f64,
+    /// High value
+    pub high: f64,
+    /// Low value
+    pub low: f64,
+    /// Close value
+    pub close: f64,
+}
+
+/// Response from get_volatility_index_data
+///
+/// Contains volatility index candles and optional continuation token.
+#[skip_serializing_none]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VolatilityIndexData {
+    /// Candles as OHLC data
+    #[serde(deserialize_with = "deserialize_candles")]
+    pub data: Vec<VolatilityIndexCandle>,
+    /// Continuation token for pagination (use as end_timestamp for next request)
+    pub continuation: Option<u64>,
+}
+
+/// Deserialize candles from array of arrays format
+fn deserialize_candles<'de, D>(deserializer: D) -> Result<Vec<VolatilityIndexCandle>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error;
+    let raw: Vec<Vec<serde_json::Value>> = Vec::deserialize(deserializer)?;
+    let mut candles = Vec::with_capacity(raw.len());
+
+    for arr in raw {
+        if arr.len() != 5 {
+            return Err(D::Error::custom(format!(
+                "expected 5 elements in candle array, got {}",
+                arr.len()
+            )));
+        }
+        let timestamp = arr[0]
+            .as_u64()
+            .ok_or_else(|| D::Error::custom("invalid timestamp"))?;
+        let open = arr[1]
+            .as_f64()
+            .ok_or_else(|| D::Error::custom("invalid open"))?;
+        let high = arr[2]
+            .as_f64()
+            .ok_or_else(|| D::Error::custom("invalid high"))?;
+        let low = arr[3]
+            .as_f64()
+            .ok_or_else(|| D::Error::custom("invalid low"))?;
+        let close = arr[4]
+            .as_f64()
+            .ok_or_else(|| D::Error::custom("invalid close"))?;
+
+        candles.push(VolatilityIndexCandle {
+            timestamp,
+            open,
+            high,
+            low,
+            close,
+        });
+    }
+
+    Ok(candles)
+}
+
 /// Account summary information
 #[skip_serializing_none]
 #[derive(DebugPretty, DisplaySimple, Clone, Serialize, Deserialize)]

--- a/tests/unit/response_other_tests.rs
+++ b/tests/unit/response_other_tests.rs
@@ -991,3 +991,141 @@ fn test_trade_volume_equality() {
 
     assert_eq!(vol1, vol2);
 }
+
+// Tests for VolatilityIndexCandle and VolatilityIndexData
+#[test]
+fn test_volatility_index_candle_creation() {
+    let candle = VolatilityIndexCandle {
+        timestamp: 1598019300000,
+        open: 0.210084879,
+        high: 0.212860821,
+        low: 0.210084879,
+        close: 0.212860821,
+    };
+
+    assert_eq!(candle.timestamp, 1598019300000);
+    assert!((candle.open - 0.210084879).abs() < 1e-9);
+    assert!((candle.close - 0.212860821).abs() < 1e-9);
+}
+
+#[test]
+fn test_volatility_index_data_deserialization() {
+    let json = r#"{
+        "data": [
+            [1598019300000, 0.210084879, 0.212860821, 0.210084879, 0.212860821],
+            [1598019360000, 0.212869011, 0.212987527, 0.212869011, 0.212987527]
+        ],
+        "continuation": null
+    }"#;
+
+    let data: VolatilityIndexData = serde_json::from_str(json).unwrap();
+    assert_eq!(data.data.len(), 2);
+    assert_eq!(data.data[0].timestamp, 1598019300000);
+    assert!((data.data[0].open - 0.210084879).abs() < 1e-9);
+    assert!(data.continuation.is_none());
+}
+
+#[test]
+fn test_volatility_index_data_with_continuation() {
+    let json = r#"{
+        "data": [
+            [1598019300000, 0.21, 0.22, 0.20, 0.215]
+        ],
+        "continuation": 1598019400000
+    }"#;
+
+    let data: VolatilityIndexData = serde_json::from_str(json).unwrap();
+    assert_eq!(data.data.len(), 1);
+    assert_eq!(data.continuation, Some(1598019400000));
+}
+
+#[test]
+fn test_volatility_index_data_empty() {
+    let json = r#"{
+        "data": [],
+        "continuation": null
+    }"#;
+
+    let data: VolatilityIndexData = serde_json::from_str(json).unwrap();
+    assert!(data.data.is_empty());
+    assert!(data.continuation.is_none());
+}
+
+#[test]
+fn test_volatility_index_candle_clone() {
+    let candle = VolatilityIndexCandle {
+        timestamp: 1598019300000,
+        open: 0.21,
+        high: 0.22,
+        low: 0.20,
+        close: 0.215,
+    };
+    let cloned = candle.clone();
+
+    assert_eq!(candle.timestamp, cloned.timestamp);
+    assert_eq!(candle.close, cloned.close);
+}
+
+#[test]
+fn test_volatility_index_data_clone() {
+    let data = VolatilityIndexData {
+        data: vec![VolatilityIndexCandle {
+            timestamp: 1598019300000,
+            open: 0.21,
+            high: 0.22,
+            low: 0.20,
+            close: 0.215,
+        }],
+        continuation: Some(1598019400000),
+    };
+    let cloned = data.clone();
+
+    assert_eq!(data.data.len(), cloned.data.len());
+    assert_eq!(data.continuation, cloned.continuation);
+}
+
+#[test]
+fn test_volatility_index_candle_equality() {
+    let candle1 = VolatilityIndexCandle {
+        timestamp: 1598019300000,
+        open: 0.21,
+        high: 0.22,
+        low: 0.20,
+        close: 0.215,
+    };
+    let candle2 = VolatilityIndexCandle {
+        timestamp: 1598019300000,
+        open: 0.21,
+        high: 0.22,
+        low: 0.20,
+        close: 0.215,
+    };
+
+    assert_eq!(candle1, candle2);
+}
+
+#[test]
+fn test_volatility_index_data_equality() {
+    let data1 = VolatilityIndexData {
+        data: vec![VolatilityIndexCandle {
+            timestamp: 1598019300000,
+            open: 0.21,
+            high: 0.22,
+            low: 0.20,
+            close: 0.215,
+        }],
+        continuation: None,
+    };
+    let data2 = VolatilityIndexData {
+        data: vec![VolatilityIndexCandle {
+            timestamp: 1598019300000,
+            open: 0.21,
+            high: 0.22,
+            low: 0.20,
+            close: 0.215,
+        }],
+        continuation: None,
+    };
+
+    assert_eq!(data1, data2);
+}


### PR DESCRIPTION
## Summary

Implement the `public/get_volatility_index_data` endpoint to retrieve VIX candle chart data.

## Changes

### Constant (`src/constants.rs`)
- `GET_VOLATILITY_INDEX_DATA` — endpoint path constant

### Models (`src/model/response/other.rs`)
- `VolatilityIndexCandle` — OHLC candle (timestamp, open, high, low, close)
- `VolatilityIndexData` — response with candles and continuation token
- Custom deserializer for array-of-arrays candle format

### Method (`src/endpoints/public.rs`)
- `get_volatility_index_data(currency, start_timestamp, end_timestamp, resolution)` — returns `VolatilityIndexData`

## Testing

- [x] Unit tests added (8 tests for volatility index models)
- [x] Manual testing performed (`make pre-push`)

## Checklist

- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] No `.unwrap()`, `.expect()`, or panics in library code
- [x] Minimal dependencies — no unnecessary crates added

Closes #11
