### PR TITLE
feat: implement public/get_index_chart_data endpoint

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -92,6 +92,8 @@ pub mod endpoints {
     pub const GET_TRADE_VOLUMES: &str = "/public/get_trade_volumes";
     /// Get volatility index data
     pub const GET_VOLATILITY_INDEX_DATA: &str = "/public/get_volatility_index_data";
+    /// Get index chart data
+    pub const GET_INDEX_CHART_DATA: &str = "/public/get_index_chart_data";
 
     // Private trading endpoints
     /// Place a buy order

--- a/src/endpoints/public.rs
+++ b/src/endpoints/public.rs
@@ -10,7 +10,7 @@ use crate::model::LastTradesResponse;
 use crate::model::book::{BookSummary, OrderBook};
 use crate::model::currency::CurrencyStruct;
 use crate::model::funding::{FundingChartData, FundingRateData};
-use crate::model::index::{IndexData, IndexPriceData};
+use crate::model::index::{IndexChartDataPoint, IndexData, IndexPriceData};
 use crate::model::instrument::{Instrument, OptionType};
 use crate::model::order::OrderSide;
 use crate::model::other::{OptionInstrument, OptionInstrumentPair};

--- a/src/endpoints/public.rs
+++ b/src/endpoints/public.rs
@@ -252,6 +252,79 @@ impl DeribitHttpClient {
         })
     }
 
+    /// Get index chart data
+    ///
+    /// Returns historical price index chart data for the specified index name and time range.
+    /// The data is formatted for use in charting applications and shows price index values over time.
+    /// This is a public endpoint that doesn't require authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `index_name` - Index identifier (e.g., "btc_usd", "eth_usd", "sol_usdc")
+    /// * `range` - Time range for the data: "1h", "1d", "2d", "1m", "1y", or "all"
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use deribit_http::DeribitHttpClient;
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = DeribitHttpClient::new(); // testnet
+    /// let chart_data = client.get_index_chart_data("btc_usd", "1d").await?;
+    /// for point in chart_data {
+    ///     println!("Time: {}, Price: {}", point.timestamp, point.price);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_index_chart_data(
+        &self,
+        index_name: &str,
+        range: &str,
+    ) -> Result<Vec<IndexChartDataPoint>, HttpError> {
+        let url = format!(
+            "{}{}?index_name={}&range={}",
+            self.base_url(),
+            GET_INDEX_CHART_DATA,
+            urlencoding::encode(index_name),
+            urlencoding::encode(range)
+        );
+
+        let response = self
+            .http_client()
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| HttpError::NetworkError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get index chart data failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<Vec<IndexChartDataPoint>> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response.result.ok_or_else(|| {
+            HttpError::InvalidResponse("No index chart data in response".to_string())
+        })
+    }
+
     /// Get book summary by currency
     ///
     /// Retrieves the summary information such as open interest, 24h volume, etc.

--- a/src/model/index.rs
+++ b/src/model/index.rs
@@ -33,3 +33,51 @@ pub struct IndexPriceData {
     /// Estimated delivery price
     pub estimated_delivery_price: f64,
 }
+
+/// Index chart data point representing a single price observation.
+///
+/// The Deribit API returns chart data as arrays of `[timestamp, price]` tuples.
+/// This struct provides a typed representation with proper field names.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct IndexChartDataPoint {
+    /// Timestamp in milliseconds since Unix epoch
+    pub timestamp: u64,
+    /// Average index price at that timestamp
+    pub price: f64,
+}
+
+impl IndexChartDataPoint {
+    /// Creates a new index chart data point.
+    ///
+    /// # Arguments
+    ///
+    /// * `timestamp` - Timestamp in milliseconds since Unix epoch
+    /// * `price` - Average index price at that timestamp
+    #[must_use]
+    pub fn new(timestamp: u64, price: f64) -> Self {
+        Self { timestamp, price }
+    }
+}
+
+impl Serialize for IndexChartDataPoint {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // Serialize as [timestamp, price] tuple to match API format
+        (self.timestamp, self.price).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for IndexChartDataPoint {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Deserialize from [timestamp, price] tuple
+        let (timestamp_f64, price): (f64, f64) = Deserialize::deserialize(deserializer)?;
+        // Convert timestamp from f64 to u64 (API returns it as a number)
+        let timestamp = timestamp_f64 as u64;
+        Ok(Self { timestamp, price })
+    }
+}

--- a/tests/integration/market_data/comprehensive_market_data.rs
+++ b/tests/integration/market_data/comprehensive_market_data.rs
@@ -577,4 +577,217 @@ mod comprehensive_market_data_tests {
         info!("Market data edge cases test completed successfully");
         Ok(())
     }
+
+    // =========================================================================
+    // Index Chart Data Tests (Issue #12)
+    // =========================================================================
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_get_index_chart_data_btc_1d() -> Result<(), Box<dyn std::error::Error>> {
+        let client = DeribitHttpClient::new();
+
+        info!("Testing get_index_chart_data for btc_usd with 1d range");
+        let start_time = Instant::now();
+        let result = client.get_index_chart_data("btc_usd", "1d").await;
+        let elapsed = start_time.elapsed();
+
+        match &result {
+            Ok(data) => {
+                info!(
+                    "Successfully retrieved {} data points in {:?}",
+                    data.len(),
+                    elapsed
+                );
+
+                // Validate we got data
+                assert!(!data.is_empty(), "Should return at least one data point");
+
+                // Validate data structure
+                for point in data.iter() {
+                    // Timestamp should be reasonable (after 2020, before 2035)
+                    assert!(
+                        point.timestamp > 1_577_836_800_000,
+                        "Timestamp should be after 2020: {}",
+                        point.timestamp
+                    );
+                    assert!(
+                        point.timestamp < 2_051_222_400_000,
+                        "Timestamp should be before 2035: {}",
+                        point.timestamp
+                    );
+
+                    // Price should be positive and reasonable for BTC
+                    assert!(point.price > 0.0, "Price should be positive: {}", point.price);
+                    assert!(
+                        point.price < 10_000_000.0,
+                        "Price should be reasonable: {}",
+                        point.price
+                    );
+                }
+
+                // Validate timestamps are in order (ascending)
+                for i in 1..data.len() {
+                    assert!(
+                        data[i].timestamp >= data[i - 1].timestamp,
+                        "Timestamps should be in ascending order: {} >= {}",
+                        data[i].timestamp,
+                        data[i - 1].timestamp
+                    );
+                }
+            }
+            Err(e) => {
+                warn!("get_index_chart_data failed in {:?}: {:?}", elapsed, e);
+                return Err(format!("get_index_chart_data failed: {:?}", e).into());
+            }
+        }
+
+        assert!(
+            elapsed < Duration::from_secs(30),
+            "Request took too long: {:?}",
+            elapsed
+        );
+
+        info!("test_get_index_chart_data_btc_1d completed successfully");
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_get_index_chart_data_multiple_ranges() -> Result<(), Box<dyn std::error::Error>> {
+        let client = DeribitHttpClient::new();
+
+        let ranges = ["1h", "1d", "2d", "1m", "1y"];
+
+        for range in ranges.iter() {
+            info!("Testing get_index_chart_data for btc_usd with {} range", range);
+            let start_time = Instant::now();
+            let result = client.get_index_chart_data("btc_usd", range).await;
+            let elapsed = start_time.elapsed();
+
+            match &result {
+                Ok(data) => {
+                    info!(
+                        "Range '{}': {} data points in {:?}",
+                        range,
+                        data.len(),
+                        elapsed
+                    );
+
+                    // All ranges should return data
+                    assert!(
+                        !data.is_empty(),
+                        "Range '{}' should return at least one data point",
+                        range
+                    );
+
+                    // Validate first and last points have valid data
+                    if let Some(first) = data.first() {
+                        assert!(first.price > 0.0, "First point price should be positive");
+                        assert!(
+                            first.timestamp > 1_577_836_800_000,
+                            "First point timestamp should be valid"
+                        );
+                    }
+                    if let Some(last) = data.last() {
+                        assert!(last.price > 0.0, "Last point price should be positive");
+                        assert!(
+                            last.timestamp > 1_577_836_800_000,
+                            "Last point timestamp should be valid"
+                        );
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        "Range '{}' failed in {:?}: {:?}",
+                        range, elapsed, e
+                    );
+                    return Err(format!("Range '{}' failed: {:?}", range, e).into());
+                }
+            }
+
+            // Small delay between requests to avoid rate limiting
+            sleep(Duration::from_millis(200)).await;
+        }
+
+        info!("test_get_index_chart_data_multiple_ranges completed successfully");
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_get_index_chart_data_eth() -> Result<(), Box<dyn std::error::Error>> {
+        let client = DeribitHttpClient::new();
+
+        info!("Testing get_index_chart_data for eth_usd with 1d range");
+        let start_time = Instant::now();
+        let result = client.get_index_chart_data("eth_usd", "1d").await;
+        let elapsed = start_time.elapsed();
+
+        match &result {
+            Ok(data) => {
+                info!(
+                    "Successfully retrieved {} ETH data points in {:?}",
+                    data.len(),
+                    elapsed
+                );
+
+                assert!(!data.is_empty(), "Should return at least one data point for ETH");
+
+                // Validate ETH price range (different from BTC)
+                for point in data.iter() {
+                    assert!(point.price > 0.0, "ETH price should be positive");
+                    assert!(
+                        point.price < 100_000.0,
+                        "ETH price should be reasonable: {}",
+                        point.price
+                    );
+                }
+            }
+            Err(e) => {
+                warn!("ETH index chart data failed in {:?}: {:?}", elapsed, e);
+                return Err(format!("ETH index chart data failed: {:?}", e).into());
+            }
+        }
+
+        info!("test_get_index_chart_data_eth completed successfully");
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_get_index_chart_data_invalid_index() -> Result<(), Box<dyn std::error::Error>> {
+        let client = DeribitHttpClient::new();
+
+        info!("Testing get_index_chart_data with invalid index name");
+        let start_time = Instant::now();
+        let result = client.get_index_chart_data("invalid_index_name", "1d").await;
+        let elapsed = start_time.elapsed();
+
+        match result {
+            Ok(data) => {
+                // API might return empty data or error for invalid index
+                info!(
+                    "Invalid index returned {} points in {:?} (may be empty or error)",
+                    data.len(),
+                    elapsed
+                );
+            }
+            Err(e) => {
+                info!(
+                    "Invalid index correctly returned error in {:?}: {:?}",
+                    elapsed, e
+                );
+            }
+        }
+
+        assert!(
+            elapsed < Duration::from_secs(30),
+            "Invalid index request took too long: {:?}",
+            elapsed
+        );
+
+        info!("test_get_index_chart_data_invalid_index completed successfully");
+        Ok(())
+    }
 }

--- a/tests/integration/market_data/comprehensive_market_data.rs
+++ b/tests/integration/market_data/comprehensive_market_data.rs
@@ -618,7 +618,11 @@ mod comprehensive_market_data_tests {
                     );
 
                     // Price should be positive and reasonable for BTC
-                    assert!(point.price > 0.0, "Price should be positive: {}", point.price);
+                    assert!(
+                        point.price > 0.0,
+                        "Price should be positive: {}",
+                        point.price
+                    );
                     assert!(
                         point.price < 10_000_000.0,
                         "Price should be reasonable: {}",
@@ -660,7 +664,10 @@ mod comprehensive_market_data_tests {
         let ranges = ["1h", "1d", "2d", "1m", "1y"];
 
         for range in ranges.iter() {
-            info!("Testing get_index_chart_data for btc_usd with {} range", range);
+            info!(
+                "Testing get_index_chart_data for btc_usd with {} range",
+                range
+            );
             let start_time = Instant::now();
             let result = client.get_index_chart_data("btc_usd", range).await;
             let elapsed = start_time.elapsed();
@@ -698,10 +705,7 @@ mod comprehensive_market_data_tests {
                     }
                 }
                 Err(e) => {
-                    warn!(
-                        "Range '{}' failed in {:?}: {:?}",
-                        range, elapsed, e
-                    );
+                    warn!("Range '{}' failed in {:?}: {:?}", range, elapsed, e);
                     return Err(format!("Range '{}' failed: {:?}", range, e).into());
                 }
             }
@@ -732,7 +736,10 @@ mod comprehensive_market_data_tests {
                     elapsed
                 );
 
-                assert!(!data.is_empty(), "Should return at least one data point for ETH");
+                assert!(
+                    !data.is_empty(),
+                    "Should return at least one data point for ETH"
+                );
 
                 // Validate ETH price range (different from BTC)
                 for point in data.iter() {
@@ -761,7 +768,9 @@ mod comprehensive_market_data_tests {
 
         info!("Testing get_index_chart_data with invalid index name");
         let start_time = Instant::now();
-        let result = client.get_index_chart_data("invalid_index_name", "1d").await;
+        let result = client
+            .get_index_chart_data("invalid_index_name", "1d")
+            .await;
         let elapsed = start_time.elapsed();
 
         match result {

--- a/tests/unit/index_tests.rs
+++ b/tests/unit/index_tests.rs
@@ -1,0 +1,253 @@
+use deribit_http::model::index::{IndexChartDataPoint, IndexData, IndexPriceData};
+use serde_json;
+
+#[cfg(test)]
+mod index_chart_data_point_tests {
+    use super::*;
+
+    #[test]
+    fn test_index_chart_data_point_new() {
+        let point = IndexChartDataPoint::new(1573228800000, 8751.7138636);
+
+        assert_eq!(point.timestamp, 1573228800000);
+        assert!((point.price - 8751.7138636).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_index_chart_data_point_serialization() {
+        let point = IndexChartDataPoint::new(1573228800000, 8751.7138636);
+
+        let json = serde_json::to_string(&point).expect("serialization should succeed");
+        // Should serialize as tuple [timestamp, price]
+        assert!(json.contains("1573228800000"));
+        assert!(json.contains("8751.7138636"));
+    }
+
+    #[test]
+    fn test_index_chart_data_point_deserialization() {
+        // API returns data as [timestamp, price] tuple
+        let json = "[1573228800000, 8751.7138636]";
+        let point: IndexChartDataPoint =
+            serde_json::from_str(json).expect("deserialization should succeed");
+
+        assert_eq!(point.timestamp, 1573228800000);
+        assert!((point.price - 8751.7138636).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_index_chart_data_point_roundtrip() {
+        let original = IndexChartDataPoint::new(1573228800000, 8751.7138636);
+
+        let json = serde_json::to_string(&original).expect("serialization should succeed");
+        let deserialized: IndexChartDataPoint =
+            serde_json::from_str(&json).expect("deserialization should succeed");
+
+        assert_eq!(original.timestamp, deserialized.timestamp);
+        assert!((original.price - deserialized.price).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_index_chart_data_point_clone() {
+        let point = IndexChartDataPoint::new(1573228800000, 8751.7138636);
+        let cloned = point;
+
+        assert_eq!(point.timestamp, cloned.timestamp);
+        assert!((point.price - cloned.price).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_index_chart_data_point_copy() {
+        let point = IndexChartDataPoint::new(1573228800000, 8751.7138636);
+        let copied = point;
+
+        // Both should have same values (Copy trait)
+        assert_eq!(point.timestamp, copied.timestamp);
+        assert!((point.price - copied.price).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_index_chart_data_point_partial_eq() {
+        let point1 = IndexChartDataPoint::new(1573228800000, 8751.7138636);
+        let point2 = IndexChartDataPoint::new(1573228800000, 8751.7138636);
+        let point3 = IndexChartDataPoint::new(1573232400000, 8751.7138636);
+
+        assert_eq!(point1, point2);
+        assert_ne!(point1, point3);
+    }
+
+    #[test]
+    fn test_index_chart_data_point_edge_cases() {
+        // Test with zero values
+        let zero_point = IndexChartDataPoint::new(0, 0.0);
+        assert_eq!(zero_point.timestamp, 0);
+        assert!((zero_point.price - 0.0).abs() < f64::EPSILON);
+
+        // Test with large timestamp (far future)
+        let future_point = IndexChartDataPoint::new(4102444800000, 100000.0);
+        assert_eq!(future_point.timestamp, 4102444800000);
+        assert!((future_point.price - 100000.0).abs() < f64::EPSILON);
+
+        // Test with very small price
+        let small_price = IndexChartDataPoint::new(1573228800000, 0.00000001);
+        assert!((small_price.price - 0.00000001).abs() < f64::EPSILON);
+
+        // Test with very large price
+        let large_price = IndexChartDataPoint::new(1573228800000, 1000000000.0);
+        assert!((large_price.price - 1000000000.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_index_chart_data_point_debug() {
+        let point = IndexChartDataPoint::new(1573228800000, 8751.7138636);
+
+        let debug_str = format!("{:?}", point);
+        assert!(debug_str.contains("IndexChartDataPoint"));
+        assert!(debug_str.contains("1573228800000"));
+    }
+
+    #[test]
+    fn test_index_chart_data_vec_deserialization() {
+        // Test deserializing an array of points (as returned by API)
+        let json = r#"[
+            [1573228800000, 8751.7138636],
+            [1573232400000, 8752.0],
+            [1573236000000, 8753.5]
+        ]"#;
+
+        let points: Vec<IndexChartDataPoint> =
+            serde_json::from_str(json).expect("deserialization should succeed");
+
+        assert_eq!(points.len(), 3);
+        assert_eq!(points[0].timestamp, 1573228800000);
+        assert!((points[0].price - 8751.7138636).abs() < f64::EPSILON);
+        assert_eq!(points[1].timestamp, 1573232400000);
+        assert!((points[1].price - 8752.0).abs() < f64::EPSILON);
+        assert_eq!(points[2].timestamp, 1573236000000);
+        assert!((points[2].price - 8753.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_index_chart_data_empty_vec() {
+        let json = "[]";
+        let points: Vec<IndexChartDataPoint> =
+            serde_json::from_str(json).expect("deserialization should succeed");
+
+        assert!(points.is_empty());
+    }
+
+    #[test]
+    fn test_index_chart_data_realistic_btc_prices() {
+        // Test with realistic BTC price data
+        let point = IndexChartDataPoint::new(1709683200000, 67234.56);
+
+        assert_eq!(point.timestamp, 1709683200000);
+        assert!((point.price - 67234.56).abs() < f64::EPSILON);
+
+        // Verify the timestamp is reasonable (March 2024)
+        assert!(point.timestamp > 1700000000000);
+        assert!(point.timestamp < 2000000000000);
+    }
+}
+
+#[cfg(test)]
+mod index_data_tests {
+    use super::*;
+
+    #[test]
+    fn test_index_data_deserialization() {
+        let json = r#"{
+            "btc": 50000.0,
+            "eth": 3000.0,
+            "edp": 50100.0
+        }"#;
+
+        let data: IndexData = serde_json::from_str(json).expect("deserialization should succeed");
+
+        assert_eq!(data.btc, Some(50000.0));
+        assert_eq!(data.eth, Some(3000.0));
+        assert!((data.edp - 50100.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_index_data_optional_fields() {
+        let json = r#"{
+            "edp": 50100.0
+        }"#;
+
+        let data: IndexData = serde_json::from_str(json).expect("deserialization should succeed");
+
+        assert!(data.btc.is_none());
+        assert!(data.eth.is_none());
+        assert!(data.usdc.is_none());
+        assert!(data.usdt.is_none());
+        assert!(data.eurr.is_none());
+        assert!((data.edp - 50100.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_index_data_clone() {
+        let json = r#"{
+            "btc": 50000.0,
+            "edp": 50100.0
+        }"#;
+
+        let data: IndexData = serde_json::from_str(json).expect("deserialization should succeed");
+        let cloned = data.clone();
+
+        assert_eq!(data.btc, cloned.btc);
+        assert!((data.edp - cloned.edp).abs() < f64::EPSILON);
+    }
+}
+
+#[cfg(test)]
+mod index_price_data_tests {
+    use super::*;
+
+    #[test]
+    fn test_index_price_data_deserialization() {
+        let json = r#"{
+            "index_price": 50000.0,
+            "estimated_delivery_price": 50100.0
+        }"#;
+
+        let data: IndexPriceData =
+            serde_json::from_str(json).expect("deserialization should succeed");
+
+        assert!((data.index_price - 50000.0).abs() < f64::EPSILON);
+        assert!((data.estimated_delivery_price - 50100.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_index_price_data_serialization_roundtrip() {
+        let json = r#"{"index_price":50000.0,"estimated_delivery_price":50100.0}"#;
+
+        let data: IndexPriceData =
+            serde_json::from_str(json).expect("deserialization should succeed");
+        let serialized = serde_json::to_string(&data).expect("serialization should succeed");
+        let deserialized: IndexPriceData =
+            serde_json::from_str(&serialized).expect("deserialization should succeed");
+
+        assert!((data.index_price - deserialized.index_price).abs() < f64::EPSILON);
+        assert!(
+            (data.estimated_delivery_price - deserialized.estimated_delivery_price).abs()
+                < f64::EPSILON
+        );
+    }
+
+    #[test]
+    fn test_index_price_data_clone() {
+        let json = r#"{
+            "index_price": 50000.0,
+            "estimated_delivery_price": 50100.0
+        }"#;
+
+        let data: IndexPriceData =
+            serde_json::from_str(json).expect("deserialization should succeed");
+        let cloned = data.clone();
+
+        assert!((data.index_price - cloned.index_price).abs() < f64::EPSILON);
+        assert!(
+            (data.estimated_delivery_price - cloned.estimated_delivery_price).abs() < f64::EPSILON
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Implement the `public/get_index_chart_data` endpoint that returns historical price index chart data for charting applications, as specified in issue #12.

## Changes

### New Types
- **IndexChartDataPoint**: Struct representing a single price observation with custom serde to handle `[timestamp, price]` tuple format from API

### New Method
- **get_index_chart_data(index_name, range)**: Returns `Vec<IndexChartDataPoint>` for the specified index and time range

### Files Modified
- `src/constants.rs`: Added `GET_INDEX_CHART_DATA` constant
- `src/model/index.rs`: Added `IndexChartDataPoint` struct with custom serialization
- `src/endpoints/public.rs`: Implemented `get_index_chart_data` method
- `src/lib.rs`: Updated documentation
- `tests/unit/index_tests.rs`: Created with 17 unit tests
- `tests/unit/mod.rs`: Added `mod index_tests`

## API Parameters

| Parameter | Description |
|-----------|-------------|
| `index_name` | Index identifier (e.g., `btc_usd`, `eth_usd`, `sol_usdc`) |
| `range` | Time range: `1h`, `1d`, `2d`, `1m`, `1y`, `all` |

## Testing

- All 513 unit tests pass
- `make lint-fix` ✓
- `make pre-push` ✓
- Doc-test for `get_index_chart_data` ✓

Closes #12