### PR TITLE
M1 #13: Implement private/close_position endpoint

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -118,6 +118,8 @@ pub mod endpoints {
     pub const EDIT: &str = "/private/edit";
     /// Cancel quotes
     pub const CANCEL_QUOTES: &str = "/private/cancel_quotes";
+    /// Close an existing position
+    pub const CLOSE_POSITION: &str = "/private/close_position";
 
     // Private account endpoints
     /// Get account summary information

--- a/src/endpoints/private.rs
+++ b/src/endpoints/private.rs
@@ -1329,6 +1329,81 @@ impl DeribitHttpClient {
     //
     // }
 
+    /// Close an existing position
+    ///
+    /// Places a reduce-only order to close an existing position. The order will
+    /// automatically be set to reduce-only to ensure it only closes the position.
+    ///
+    /// # Arguments
+    ///
+    /// * `instrument_name` - Instrument identifier (e.g., "BTC-PERPETUAL")
+    /// * `order_type` - Order type: "market" or "limit"
+    /// * `price` - Optional price for limit orders (required if order_type is "limit")
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // Close position with market order
+    /// // let result = client.close_position("BTC-PERPETUAL", "market", None).await?;
+    /// // Close position with limit order
+    /// // let result = client.close_position("ETH-PERPETUAL", "limit", Some(2500.0)).await?;
+    /// ```
+    pub async fn close_position(
+        &self,
+        instrument_name: &str,
+        order_type: &str,
+        price: Option<f64>,
+    ) -> Result<OrderResponse, HttpError> {
+        let mut query_params = vec![
+            ("instrument_name".to_string(), instrument_name.to_string()),
+            ("type".to_string(), order_type.to_string()),
+        ];
+
+        if let Some(price) = price {
+            query_params.push(("price".to_string(), price.to_string()));
+        }
+
+        let query_string = query_params
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
+            .collect::<Vec<_>>()
+            .join("&");
+
+        let url = format!("{}{}?{}", self.base_url(), CLOSE_POSITION, query_string);
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Close position failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<OrderResponse> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No order data in response".to_string()))
+    }
+
     /// Mass quote
     ///
     /// Places multiple quotes at once.

--- a/tests/integration/order_management/mod.rs
+++ b/tests/integration/order_management/mod.rs
@@ -5,3 +5,98 @@
 
 // Note: Order management tests can be added here as needed
 // These tests cover private trading endpoints that require authentication
+
+#[cfg(test)]
+mod close_position_tests {
+    use deribit_http::DeribitHttpClient;
+    use tokio::time::{Duration, Instant};
+    use tracing::info;
+
+    /// Test close_position endpoint behavior
+    ///
+    /// Note: This test requires authentication and an open position.
+    /// It will attempt to close a position and verify the response structure.
+    /// If no position exists, the API will return an error which is expected.
+    #[tokio::test]
+    #[serial_test::serial]
+    #[ignore = "Requires authentication and may affect real positions"]
+    async fn test_close_position_market_order() -> Result<(), Box<dyn std::error::Error>> {
+        let client = DeribitHttpClient::new();
+
+        info!("Testing close_position with market order");
+        let start_time = Instant::now();
+        let result = client.close_position("BTC-PERPETUAL", "market", None).await;
+        let elapsed = start_time.elapsed();
+
+        match &result {
+            Ok(response) => {
+                info!(
+                    "Close position succeeded in {:?}: order_id={}, state={}",
+                    elapsed, response.order.order_id, response.order.order_state
+                );
+                // Verify reduce_only is true (required for close_position)
+                assert!(
+                    response.order.reduce_only,
+                    "Close position order should be reduce_only"
+                );
+            }
+            Err(e) => {
+                // Expected if no position exists
+                info!(
+                    "Close position failed in {:?} (expected if no position): {:?}",
+                    elapsed, e
+                );
+            }
+        }
+
+        assert!(
+            elapsed < Duration::from_secs(30),
+            "Request took too long: {:?}",
+            elapsed
+        );
+
+        info!("test_close_position_market_order completed");
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    #[ignore = "Requires authentication and may affect real positions"]
+    async fn test_close_position_limit_order() -> Result<(), Box<dyn std::error::Error>> {
+        let client = DeribitHttpClient::new();
+
+        info!("Testing close_position with limit order");
+        let start_time = Instant::now();
+        // Use a price far from market to avoid accidental execution
+        let result = client
+            .close_position("BTC-PERPETUAL", "limit", Some(1.0))
+            .await;
+        let elapsed = start_time.elapsed();
+
+        match &result {
+            Ok(response) => {
+                info!(
+                    "Close position (limit) succeeded in {:?}: order_id={}, type={}",
+                    elapsed, response.order.order_id, response.order.order_type
+                );
+                assert_eq!(response.order.order_type, "limit");
+                assert!(response.order.reduce_only);
+            }
+            Err(e) => {
+                info!(
+                    "Close position (limit) failed in {:?} (expected if no position): {:?}",
+                    elapsed, e
+                );
+            }
+        }
+
+        assert!(
+            elapsed < Duration::from_secs(30),
+            "Request took too long: {:?}",
+            elapsed
+        );
+
+        info!("test_close_position_limit_order completed");
+        Ok(())
+    }
+}

--- a/tests/unit/private_endpoints_tests.rs
+++ b/tests/unit/private_endpoints_tests.rs
@@ -379,3 +379,187 @@ async fn test_submit_transfer_to_user_success() {
     }
     assert!(result.is_ok());
 }
+
+// =========================================================================
+// Close Position Tests (Issue #13)
+// =========================================================================
+
+#[tokio::test]
+async fn test_close_position_market_order_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    // Mock the OAuth2 authentication endpoint
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": {
+            "order": {
+                "amount": 10.0,
+                "api": true,
+                "average_price": 50000.0,
+                "creation_timestamp": 1609459200000u64,
+                "direction": "sell",
+                "filled_amount": 10.0,
+                "instrument_name": "BTC-PERPETUAL",
+                "is_liquidation": false,
+                "label": "",
+                "last_update_timestamp": 1609459200000u64,
+                "order_id": "ETH-123456",
+                "order_state": "filled",
+                "order_type": "market",
+                "post_only": false,
+                "price": 50000.0,
+                "reduce_only": true,
+                "replaced": false,
+                "risk_reducing": false,
+                "time_in_force": "good_til_cancelled",
+                "web": false
+            },
+            "trades": [
+                {
+                    "trade_id": "BTC-12345",
+                    "instrument_name": "BTC-PERPETUAL",
+                    "timestamp": 1609459200000u64,
+                    "direction": "sell",
+                    "price": 50000.0,
+                    "amount": 10.0,
+                    "fee": 0.0001,
+                    "fee_currency": "BTC",
+                    "order_id": "ETH-123456",
+                    "order_type": "market",
+                    "trade_seq": 1,
+                    "state": "filled",
+                    "index_price": 50000.0,
+                    "liquidity": "T",
+                    "mark_price": 50000.0,
+                    "tick_direction": 0,
+                    "self_trade": false,
+                    "label": ""
+                }
+            ]
+        },
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            "/api/v2/private/close_position?instrument_name=BTC-PERPETUAL&type=market",
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.close_position("BTC-PERPETUAL", "market", None).await;
+
+    mock.assert_async().await;
+    if let Err(e) = &result {
+        println!("Error in test_close_position_market_order_success: {:?}", e);
+    }
+    assert!(result.is_ok());
+    let response = result.unwrap();
+    assert_eq!(response.order.instrument_name, "BTC-PERPETUAL");
+    assert!(response.order.reduce_only);
+}
+
+#[tokio::test]
+async fn test_close_position_limit_order_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    // Mock the OAuth2 authentication endpoint
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": {
+            "order": {
+                "amount": 10.0,
+                "api": true,
+                "average_price": 2500.0,
+                "creation_timestamp": 1609459200000u64,
+                "direction": "sell",
+                "filled_amount": 10.0,
+                "instrument_name": "ETH-PERPETUAL",
+                "is_liquidation": false,
+                "label": "",
+                "last_update_timestamp": 1609459200000u64,
+                "order_id": "ETH-789012",
+                "order_state": "open",
+                "order_type": "limit",
+                "post_only": false,
+                "price": 2500.0,
+                "reduce_only": true,
+                "replaced": false,
+                "risk_reducing": false,
+                "time_in_force": "good_til_cancelled",
+                "web": false
+            },
+            "trades": []
+        },
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            "/api/v2/private/close_position?instrument_name=ETH-PERPETUAL&type=limit&price=2500",
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client
+        .close_position("ETH-PERPETUAL", "limit", Some(2500.0))
+        .await;
+
+    mock.assert_async().await;
+    if let Err(e) = &result {
+        println!("Error in test_close_position_limit_order_success: {:?}", e);
+    }
+    assert!(result.is_ok());
+    let response = result.unwrap();
+    assert_eq!(response.order.instrument_name, "ETH-PERPETUAL");
+    assert_eq!(response.order.order_type, "limit");
+    assert!(response.order.reduce_only);
+}
+
+#[tokio::test]
+async fn test_close_position_no_position_error() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    // Mock the OAuth2 authentication endpoint
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock = server
+        .mock(
+            "GET",
+            "/api/v2/private/close_position?instrument_name=BTC-PERPETUAL&type=market",
+        )
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": {
+                "code": 10041,
+                "message": "no_open_position"
+            }
+        }"#,
+        )
+        .create_async()
+        .await;
+
+    let result = client.close_position("BTC-PERPETUAL", "market", None).await;
+
+    mock.assert_async().await;
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary

Implement the `private/close_position` endpoint that places a reduce-only order to close an existing position.

## Changes

- Add `CLOSE_POSITION` constant in `src/constants.rs`
- Implement `close_position(instrument_name, order_type, price)` method in `src/endpoints/private.rs`
- Support both "market" and "limit" order types
- Optional price parameter for limit orders
- Add 3 unit tests with mock server
- Add 2 integration tests (ignored by default, require authentication)

## API

```rust
pub async fn close_position(
    &self,
    instrument_name: &str,
    order_type: &str,  // "market" or "limit"
    price: Option<f64>,
) -> Result<OrderResponse, HttpError>
```

## Testing

- [x] Unit tests added (3 tests: market order, limit order, error handling)
- [x] Integration tests added (2 tests, ignored by default)
- [x] Manual testing performed (`cargo test --all-features`)
- [x] Doc-test passes

## Checklist

- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] No `.unwrap()`, `.expect()`, or panics in library code
- [x] HTTP error handling implemented
- [x] Uses existing `OrderResponse` model (no new types needed)

Closes #13
