### PR TITLE
M1 #14: Implement private/edit_by_label endpoint

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -116,6 +116,8 @@ pub mod endpoints {
     pub const CANCEL_BY_LABEL: &str = "/private/cancel_by_label";
     /// Edit order
     pub const EDIT: &str = "/private/edit";
+    /// Edit order by label
+    pub const EDIT_BY_LABEL: &str = "/private/edit_by_label";
     /// Cancel quotes
     pub const CANCEL_QUOTES: &str = "/private/cancel_quotes";
     /// Close an existing position

--- a/src/endpoints/private.rs
+++ b/src/endpoints/private.rs
@@ -1324,10 +1324,133 @@ impl DeribitHttpClient {
             .ok_or_else(|| HttpError::InvalidResponse("No order data in response".to_string()))
     }
 
-    // TODO:
-    // pub async fn edit_order_by_label(&self, request: OrderRequest) -> Result<OrderResponse, HttpError> {
-    //
-    // }
+    /// Edit an order by label
+    ///
+    /// Modifies an order identified by its label. This method works only when there
+    /// is exactly one open order with the specified label.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The edit order request parameters (must include label and instrument_name)
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    /// use deribit_http::model::request::order::OrderRequest;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let request = OrderRequest {
+    /// //     label: Some("my_order_label".to_string()),
+    /// //     instrument_name: "BTC-PERPETUAL".to_string(),
+    /// //     amount: Some(150.0),
+    /// //     price: Some(50111.0),
+    /// //     ..Default::default()
+    /// // };
+    /// // let result = client.edit_order_by_label(request).await?;
+    /// ```
+    pub async fn edit_order_by_label(
+        &self,
+        request: OrderRequest,
+    ) -> Result<OrderResponse, HttpError> {
+        let label = request.label.ok_or_else(|| {
+            HttpError::RequestFailed("label is required for edit_order_by_label".to_string())
+        })?;
+
+        let mut query_params = vec![
+            ("label".to_string(), label),
+            ("instrument_name".to_string(), request.instrument_name),
+        ];
+
+        if let Some(amount) = request.amount {
+            query_params.push(("amount".to_string(), amount.to_string()));
+        }
+
+        if let Some(contracts) = request.contracts {
+            query_params.push(("contracts".to_string(), contracts.to_string()));
+        }
+
+        if let Some(price) = request.price {
+            query_params.push(("price".to_string(), price.to_string()));
+        }
+
+        if let Some(post_only) = request.post_only
+            && post_only
+        {
+            query_params.push(("post_only".to_string(), "true".to_string()));
+        }
+
+        if let Some(reduce_only) = request.reduce_only
+            && reduce_only
+        {
+            query_params.push(("reduce_only".to_string(), "true".to_string()));
+        }
+
+        if let Some(reject_post_only) = request.reject_post_only
+            && reject_post_only
+        {
+            query_params.push(("reject_post_only".to_string(), "true".to_string()));
+        }
+
+        if let Some(advanced) = request.advanced {
+            let advanced_str = match advanced {
+                crate::model::request::order::AdvancedOrderType::Usd => "usd",
+                crate::model::request::order::AdvancedOrderType::Implv => "implv",
+            };
+            query_params.push(("advanced".to_string(), advanced_str.to_string()));
+        }
+
+        if let Some(trigger_price) = request.trigger_price {
+            query_params.push(("trigger_price".to_string(), trigger_price.to_string()));
+        }
+
+        if let Some(mmp) = request.mmp
+            && mmp
+        {
+            query_params.push(("mmp".to_string(), "true".to_string()));
+        }
+
+        if let Some(valid_until) = request.valid_until {
+            query_params.push(("valid_until".to_string(), valid_until.to_string()));
+        }
+
+        let query_string = query_params
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
+            .collect::<Vec<_>>()
+            .join("&");
+
+        let url = format!("{}{}?{}", self.base_url(), EDIT_BY_LABEL, query_string);
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Edit order by label failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<OrderResponse> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No order data in response".to_string()))
+    }
 
     /// Close an existing position
     ///

--- a/tests/integration/order_management/mod.rs
+++ b/tests/integration/order_management/mod.rs
@@ -100,3 +100,82 @@ mod close_position_tests {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod edit_order_by_label_tests {
+    use deribit_http::DeribitHttpClient;
+    use deribit_http::model::request::order::OrderRequest;
+    use tokio::time::{Duration, Instant};
+    use tracing::info;
+
+    /// Test edit_order_by_label endpoint behavior
+    ///
+    /// Note: This test requires authentication and an existing order with a specific label.
+    /// It will attempt to edit an order and verify the response structure.
+    /// If no order with the label exists, the API will return an error which is expected.
+    #[tokio::test]
+    #[serial_test::serial]
+    #[ignore = "Requires authentication and an existing order with label"]
+    async fn test_edit_order_by_label() -> Result<(), Box<dyn std::error::Error>> {
+        let client = DeribitHttpClient::new();
+
+        info!("Testing edit_order_by_label");
+        let start_time = Instant::now();
+
+        let request = OrderRequest {
+            order_id: None,
+            instrument_name: "BTC-PERPETUAL".to_string(),
+            amount: Some(150.0),
+            contracts: None,
+            type_: None,
+            label: Some("test_order_label".to_string()),
+            price: Some(50000.0),
+            time_in_force: None,
+            display_amount: None,
+            post_only: None,
+            reject_post_only: None,
+            reduce_only: None,
+            trigger_price: None,
+            trigger_offset: None,
+            trigger: None,
+            advanced: None,
+            mmp: None,
+            valid_until: None,
+            linked_order_type: None,
+            trigger_fill_condition: None,
+            otoco_config: None,
+        };
+
+        let result = client.edit_order_by_label(request).await;
+        let elapsed = start_time.elapsed();
+
+        match &result {
+            Ok(response) => {
+                info!(
+                    "Edit order by label succeeded in {:?}: order_id={}, label={}",
+                    elapsed, response.order.order_id, response.order.label
+                );
+                assert!(
+                    response.order.replaced,
+                    "Order should be marked as replaced"
+                );
+            }
+            Err(e) => {
+                // Expected if no order with label exists
+                info!(
+                    "Edit order by label failed in {:?} (expected if no order with label): {:?}",
+                    elapsed, e
+                );
+            }
+        }
+
+        assert!(
+            elapsed < Duration::from_secs(30),
+            "Request took too long: {:?}",
+            elapsed
+        );
+
+        info!("test_edit_order_by_label completed");
+        Ok(())
+    }
+}

--- a/tests/unit/private_endpoints_tests.rs
+++ b/tests/unit/private_endpoints_tests.rs
@@ -563,3 +563,188 @@ async fn test_close_position_no_position_error() {
     mock.assert_async().await;
     assert!(result.is_err());
 }
+
+// =========================================================================
+// Edit Order By Label Tests (Issue #14)
+// =========================================================================
+
+#[tokio::test]
+async fn test_edit_order_by_label_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    // Mock the OAuth2 authentication endpoint
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": {
+            "order": {
+                "amount": 150.0,
+                "api": true,
+                "average_price": 0.0,
+                "creation_timestamp": 1616155547764u64,
+                "direction": "buy",
+                "filled_amount": 0.0,
+                "instrument_name": "BTC-PERPETUAL",
+                "is_liquidation": false,
+                "label": "i_love_deribit",
+                "last_update_timestamp": 1616155550773u64,
+                "max_show": 150.0,
+                "order_id": "94166",
+                "order_state": "open",
+                "order_type": "limit",
+                "post_only": false,
+                "price": 50111.0,
+                "reduce_only": false,
+                "replaced": true,
+                "risk_reducing": false,
+                "time_in_force": "good_til_cancelled",
+                "web": false
+            },
+            "trades": []
+        },
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            "/api/v2/private/edit_by_label?label=i_love_deribit&instrument_name=BTC-PERPETUAL&amount=150&price=50111",
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let request = deribit_http::model::request::order::OrderRequest {
+        order_id: None,
+        instrument_name: "BTC-PERPETUAL".to_string(),
+        amount: Some(150.0),
+        contracts: None,
+        type_: None,
+        label: Some("i_love_deribit".to_string()),
+        price: Some(50111.0),
+        time_in_force: None,
+        display_amount: None,
+        post_only: None,
+        reject_post_only: None,
+        reduce_only: None,
+        trigger_price: None,
+        trigger_offset: None,
+        trigger: None,
+        advanced: None,
+        mmp: None,
+        valid_until: None,
+        linked_order_type: None,
+        trigger_fill_condition: None,
+        otoco_config: None,
+    };
+
+    let result = client.edit_order_by_label(request).await;
+
+    mock.assert_async().await;
+    if let Err(e) = &result {
+        println!("Error in test_edit_order_by_label_success: {:?}", e);
+    }
+    assert!(result.is_ok());
+    let response = result.unwrap();
+    assert_eq!(response.order.instrument_name, "BTC-PERPETUAL");
+    assert_eq!(response.order.label, "i_love_deribit");
+    assert!(response.order.replaced);
+}
+
+#[tokio::test]
+async fn test_edit_order_by_label_missing_label_error() {
+    let server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let request = deribit_http::model::request::order::OrderRequest {
+        order_id: None,
+        instrument_name: "BTC-PERPETUAL".to_string(),
+        amount: Some(150.0),
+        contracts: None,
+        type_: None,
+        label: None, // Missing label
+        price: Some(50111.0),
+        time_in_force: None,
+        display_amount: None,
+        post_only: None,
+        reject_post_only: None,
+        reduce_only: None,
+        trigger_price: None,
+        trigger_offset: None,
+        trigger: None,
+        advanced: None,
+        mmp: None,
+        valid_until: None,
+        linked_order_type: None,
+        trigger_fill_condition: None,
+        otoco_config: None,
+    };
+
+    let result = client.edit_order_by_label(request).await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.to_string().contains("label is required"));
+}
+
+#[tokio::test]
+async fn test_edit_order_by_label_no_order_error() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    // Mock the OAuth2 authentication endpoint
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock = server
+        .mock(
+            "GET",
+            "/api/v2/private/edit_by_label?label=nonexistent_label&instrument_name=BTC-PERPETUAL&amount=150",
+        )
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": {
+                "code": 11044,
+                "message": "no_order_with_label"
+            }
+        }"#,
+        )
+        .create_async()
+        .await;
+
+    let request = deribit_http::model::request::order::OrderRequest {
+        order_id: None,
+        instrument_name: "BTC-PERPETUAL".to_string(),
+        amount: Some(150.0),
+        contracts: None,
+        type_: None,
+        label: Some("nonexistent_label".to_string()),
+        price: None,
+        time_in_force: None,
+        display_amount: None,
+        post_only: None,
+        reject_post_only: None,
+        reduce_only: None,
+        trigger_price: None,
+        trigger_offset: None,
+        trigger: None,
+        advanced: None,
+        mmp: None,
+        valid_until: None,
+        linked_order_type: None,
+        trigger_fill_condition: None,
+        otoco_config: None,
+    };
+
+    let result = client.edit_order_by_label(request).await;
+
+    mock.assert_async().await;
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary

Implement the `private/edit_by_label` endpoint that modifies an order identified by its label. This method works only when there is exactly one open order with the specified label.

## Changes

- Add `EDIT_BY_LABEL` constant in `src/constants.rs`
- Replace existing TODO with `edit_order_by_label(request)` method in `src/endpoints/private.rs`
- Support all API parameters: label, instrument_name, amount, contracts, price, post_only, reduce_only, reject_post_only, advanced, trigger_price, mmp, valid_until
- Add 3 unit tests with mock server
- Add 1 integration test (ignored by default, requires authentication)

## API

```rust
pub async fn edit_order_by_label(
    &self,
    request: OrderRequest,  // must include label and instrument_name
) -> Result<OrderResponse, HttpError>
```

## Testing

- [x] Unit tests added (3 tests: success, missing label error, no order error)
- [x] Integration test added (1 test, ignored by default)
- [x] Manual testing performed (`cargo test --all-features`)
- [x] Doc-test passes

## Checklist

- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] No `.unwrap()`, `.expect()`, or panics in library code
- [x] HTTP error handling implemented
- [x] Uses existing `OrderRequest` and `OrderResponse` models

Closes #14
