### PR TITLE
M1 #15: Implement private/get_margins endpoint

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -122,6 +122,8 @@ pub mod endpoints {
     pub const CANCEL_QUOTES: &str = "/private/cancel_quotes";
     /// Close an existing position
     pub const CLOSE_POSITION: &str = "/private/close_position";
+    /// Get margin requirements
+    pub const GET_MARGINS: &str = "/private/get_margins";
 
     // Private account endpoints
     /// Get account summary information

--- a/src/endpoints/private.rs
+++ b/src/endpoints/private.rs
@@ -10,6 +10,7 @@ use crate::model::request::order::OrderRequest;
 use crate::model::request::trade::TradesRequest;
 use crate::model::response::api_response::ApiResponse;
 use crate::model::response::deposit::DepositsResponse;
+use crate::model::response::margin::MarginsResponse;
 use crate::model::response::mass_quote::MassQuoteResponse;
 use crate::model::response::order::{OrderInfoResponse, OrderResponse};
 use crate::model::response::other::{
@@ -1525,6 +1526,77 @@ impl DeribitHttpClient {
         api_response
             .result
             .ok_or_else(|| HttpError::InvalidResponse("No order data in response".to_string()))
+    }
+
+    /// Get margin requirements
+    ///
+    /// Calculates margin requirements for a hypothetical order on a given instrument.
+    /// Returns initial margin and maintenance margin for the specified instrument,
+    /// quantity, and price.
+    ///
+    /// # Arguments
+    ///
+    /// * `instrument_name` - Instrument identifier (e.g., "BTC-PERPETUAL")
+    /// * `amount` - Order size (USD for perpetual/inverse, base currency for options/linear)
+    /// * `price` - Order price
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let margins = client.get_margins("BTC-PERPETUAL", 10000.0, 50000.0).await?;
+    /// // println!("Buy margin: {}, Sell margin: {}", margins.buy, margins.sell);
+    /// ```
+    pub async fn get_margins(
+        &self,
+        instrument_name: &str,
+        amount: f64,
+        price: f64,
+    ) -> Result<MarginsResponse, HttpError> {
+        let query_params = [
+            ("instrument_name".to_string(), instrument_name.to_string()),
+            ("amount".to_string(), amount.to_string()),
+            ("price".to_string(), price.to_string()),
+        ];
+
+        let query_string = query_params
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
+            .collect::<Vec<_>>()
+            .join("&");
+
+        let url = format!("{}{}?{}", self.base_url(), GET_MARGINS, query_string);
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get margins failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<MarginsResponse> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No margin data in response".to_string()))
     }
 
     /// Mass quote

--- a/src/model/response/margin.rs
+++ b/src/model/response/margin.rs
@@ -1,0 +1,25 @@
+/******************************************************************************
+   Author: Joaquín Béjar García
+   Email: jb@taunais.com
+   Date: 7/3/26
+******************************************************************************/
+use pretty_simple_display::{DebugPretty, DisplaySimple};
+use serde::{Deserialize, Serialize};
+
+/// Response from the get_margins endpoint
+///
+/// Contains margin requirements for a hypothetical order on a given instrument.
+/// This is useful for estimating margin requirements before placing an order.
+#[derive(DebugPretty, DisplaySimple, Clone, Serialize, Deserialize)]
+pub struct MarginsResponse {
+    /// Margin required when buying
+    pub buy: f64,
+    /// Margin required when selling
+    pub sell: f64,
+    /// The minimum price for the future. Any sell orders submitted lower than
+    /// this price will be clamped to this minimum.
+    pub min_price: f64,
+    /// The maximum price for the future. Any buy orders submitted higher than
+    /// this price will be clamped to this maximum.
+    pub max_price: f64,
+}

--- a/src/model/response/mod.rs
+++ b/src/model/response/mod.rs
@@ -7,6 +7,8 @@
 pub mod api_response;
 /// Deposit response models
 pub mod deposit;
+/// Margin response models
+pub mod margin;
 /// Mass quote response models
 pub mod mass_quote;
 /// Order response models and types
@@ -20,6 +22,7 @@ pub mod withdrawal;
 
 pub use api_response::*;
 pub use deposit::*;
+pub use margin::*;
 pub use mass_quote::*;
 pub use order::*;
 pub use other::*;

--- a/tests/integration/order_management/mod.rs
+++ b/tests/integration/order_management/mod.rs
@@ -179,3 +179,58 @@ mod edit_order_by_label_tests {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod get_margins_tests {
+    use deribit_http::DeribitHttpClient;
+    use tokio::time::{Duration, Instant};
+    use tracing::info;
+
+    /// Test get_margins endpoint behavior
+    ///
+    /// Returns margin requirements for a hypothetical order on a given instrument.
+    #[tokio::test]
+    #[serial_test::serial]
+    #[ignore = "Requires authentication"]
+    async fn test_get_margins() -> Result<(), Box<dyn std::error::Error>> {
+        let client = DeribitHttpClient::new();
+
+        info!("Testing get_margins");
+        let start_time = Instant::now();
+
+        let result = client.get_margins("BTC-PERPETUAL", 10000.0, 50000.0).await;
+        let elapsed = start_time.elapsed();
+
+        match &result {
+            Ok(margins) => {
+                info!(
+                    "Get margins succeeded in {:?}: buy={}, sell={}, min_price={}, max_price={}",
+                    elapsed, margins.buy, margins.sell, margins.min_price, margins.max_price
+                );
+                assert!(margins.buy >= 0.0, "Buy margin should be non-negative");
+                assert!(margins.sell >= 0.0, "Sell margin should be non-negative");
+                assert!(
+                    margins.min_price > 0.0,
+                    "Min price should be positive for BTC-PERPETUAL"
+                );
+                assert!(
+                    margins.max_price > margins.min_price,
+                    "Max price should be greater than min price"
+                );
+            }
+            Err(e) => {
+                info!("Get margins failed in {:?}: {:?}", elapsed, e);
+                return Err(e.to_string().into());
+            }
+        }
+
+        assert!(
+            elapsed < Duration::from_secs(30),
+            "Request took too long: {:?}",
+            elapsed
+        );
+
+        info!("test_get_margins completed");
+        Ok(())
+    }
+}

--- a/tests/unit/private_endpoints_tests.rs
+++ b/tests/unit/private_endpoints_tests.rs
@@ -748,3 +748,85 @@ async fn test_edit_order_by_label_no_order_error() {
     mock.assert_async().await;
     assert!(result.is_err());
 }
+
+// =========================================================================
+// Get Margins Tests (Issue #15)
+// =========================================================================
+
+#[tokio::test]
+async fn test_get_margins_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    // Mock the OAuth2 authentication endpoint
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": {
+            "buy": 0.0219949,
+            "sell": 0.0,
+            "min_price": 3684.8,
+            "max_price": 3759.24
+        },
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            "/api/v2/private/get_margins?instrument_name=BTC-PERPETUAL&amount=10000&price=3725",
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.get_margins("BTC-PERPETUAL", 10000.0, 3725.0).await;
+
+    mock.assert_async().await;
+    if let Err(e) = &result {
+        println!("Error in test_get_margins_success: {:?}", e);
+    }
+    assert!(result.is_ok());
+    let margins = result.unwrap();
+    assert!((margins.buy - 0.0219949).abs() < 0.0001);
+    assert!((margins.sell - 0.0).abs() < 0.0001);
+    assert!((margins.min_price - 3684.8).abs() < 0.1);
+    assert!((margins.max_price - 3759.24).abs() < 0.1);
+}
+
+#[tokio::test]
+async fn test_get_margins_error() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    // Mock the OAuth2 authentication endpoint
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock = server
+        .mock(
+            "GET",
+            "/api/v2/private/get_margins?instrument_name=INVALID&amount=10000&price=3725",
+        )
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": {
+                "code": 10001,
+                "message": "instrument_not_found"
+            }
+        }"#,
+        )
+        .create_async()
+        .await;
+
+    let result = client.get_margins("INVALID", 10000.0, 3725.0).await;
+
+    mock.assert_async().await;
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary

Implement the `private/get_margins` endpoint that calculates margin requirements for a hypothetical order on a given instrument.

## Changes

- Add `GET_MARGINS` constant in `src/constants.rs`
- Create `MarginsResponse` model in `src/model/response/margin.rs`
- Implement `get_margins(instrument_name, amount, price)` method in `src/endpoints/private.rs`
- Add 2 unit tests with mock server
- Add 1 integration test (ignored by default, requires authentication)

## API

```rust
pub async fn get_margins(
    &self,
    instrument_name: &str,
    amount: f64,
    price: f64,
) -> Result<MarginsResponse, HttpError>
```

### Response Model

```rust
pub struct MarginsResponse {
    pub buy: f64,       // Margin required when buying
    pub sell: f64,      // Margin required when selling
    pub min_price: f64, // Minimum price (sell orders clamped)
    pub max_price: f64, // Maximum price (buy orders clamped)
}
```

## Testing

- [x] Unit tests added (2 tests: success, error handling)
- [x] Integration test added (1 test, ignored by default)
- [x] Manual testing performed (`cargo test --all-features`)
- [x] Doc-test passes

## Checklist

- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] No `.unwrap()`, `.expect()`, or panics in library code
- [x] HTTP error handling implemented
- [x] New `MarginsResponse` model created

Closes #15
