### PR TITLE
M1 #16: Implement MMP endpoints (get_mmp_config, get_mmp_status, set_mmp_config, reset_mmp)

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -124,6 +124,14 @@ pub mod endpoints {
     pub const CLOSE_POSITION: &str = "/private/close_position";
     /// Get margin requirements
     pub const GET_MARGINS: &str = "/private/get_margins";
+    /// Get MMP configuration
+    pub const GET_MMP_CONFIG: &str = "/private/get_mmp_config";
+    /// Get MMP status
+    pub const GET_MMP_STATUS: &str = "/private/get_mmp_status";
+    /// Set MMP configuration
+    pub const SET_MMP_CONFIG: &str = "/private/set_mmp_config";
+    /// Reset MMP limits
+    pub const RESET_MMP: &str = "/private/reset_mmp";
 
     // Private account endpoints
     /// Get account summary information

--- a/src/endpoints/private.rs
+++ b/src/endpoints/private.rs
@@ -12,6 +12,7 @@ use crate::model::response::api_response::ApiResponse;
 use crate::model::response::deposit::DepositsResponse;
 use crate::model::response::margin::MarginsResponse;
 use crate::model::response::mass_quote::MassQuoteResponse;
+use crate::model::response::mmp::{MmpConfig, MmpStatus, SetMmpConfigRequest};
 use crate::model::response::order::{OrderInfoResponse, OrderResponse};
 use crate::model::response::other::{
     AccountSummaryResponse, TransactionLogResponse, TransferResultResponse,
@@ -1597,6 +1598,348 @@ impl DeribitHttpClient {
         api_response
             .result
             .ok_or_else(|| HttpError::InvalidResponse("No margin data in response".to_string()))
+    }
+
+    /// Get MMP configuration
+    ///
+    /// Retrieves Market Maker Protection (MMP) configuration for an index.
+    /// If index_name is not provided, returns all MMP configurations.
+    ///
+    /// # Arguments
+    ///
+    /// * `index_name` - Index identifier (e.g., "btc_usd", "eth_usd"), optional
+    /// * `mmp_group` - MMP group name for Mass Quotes, optional
+    /// * `block_rfq` - If true, retrieve MMP config for Block RFQ, optional
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let configs = client.get_mmp_config(Some("btc_usd"), None, None).await?;
+    /// ```
+    pub async fn get_mmp_config(
+        &self,
+        index_name: Option<&str>,
+        mmp_group: Option<&str>,
+        block_rfq: Option<bool>,
+    ) -> Result<Vec<MmpConfig>, HttpError> {
+        let mut query_params: Vec<(String, String)> = Vec::new();
+
+        if let Some(index) = index_name {
+            query_params.push(("index_name".to_string(), index.to_string()));
+        }
+
+        if let Some(group) = mmp_group {
+            query_params.push(("mmp_group".to_string(), group.to_string()));
+        }
+
+        if let Some(rfq) = block_rfq
+            && rfq
+        {
+            query_params.push(("block_rfq".to_string(), "true".to_string()));
+        }
+
+        let url = if query_params.is_empty() {
+            format!("{}{}", self.base_url(), GET_MMP_CONFIG)
+        } else {
+            let query_string = query_params
+                .iter()
+                .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
+                .collect::<Vec<_>>()
+                .join("&");
+            format!("{}{}?{}", self.base_url(), GET_MMP_CONFIG, query_string)
+        };
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get MMP config failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<Vec<MmpConfig>> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No MMP config data in response".to_string()))
+    }
+
+    /// Get MMP status
+    ///
+    /// Retrieves Market Maker Protection (MMP) status for a triggered index or MMP group.
+    /// If index_name is not provided, returns all triggered MMP statuses.
+    ///
+    /// # Arguments
+    ///
+    /// * `index_name` - Index identifier (e.g., "btc_usd", "eth_usd"), optional
+    /// * `mmp_group` - MMP group name for Mass Quotes, optional
+    /// * `block_rfq` - If true, retrieve MMP status for Block RFQ, optional
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let statuses = client.get_mmp_status(Some("btc_usd"), None, None).await?;
+    /// ```
+    pub async fn get_mmp_status(
+        &self,
+        index_name: Option<&str>,
+        mmp_group: Option<&str>,
+        block_rfq: Option<bool>,
+    ) -> Result<Vec<MmpStatus>, HttpError> {
+        let mut query_params: Vec<(String, String)> = Vec::new();
+
+        if let Some(index) = index_name {
+            query_params.push(("index_name".to_string(), index.to_string()));
+        }
+
+        if let Some(group) = mmp_group {
+            query_params.push(("mmp_group".to_string(), group.to_string()));
+        }
+
+        if let Some(rfq) = block_rfq
+            && rfq
+        {
+            query_params.push(("block_rfq".to_string(), "true".to_string()));
+        }
+
+        let url = if query_params.is_empty() {
+            format!("{}{}", self.base_url(), GET_MMP_STATUS)
+        } else {
+            let query_string = query_params
+                .iter()
+                .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
+                .collect::<Vec<_>>()
+                .join("&");
+            format!("{}{}?{}", self.base_url(), GET_MMP_STATUS, query_string)
+        };
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get MMP status failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<Vec<MmpStatus>> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No MMP status data in response".to_string()))
+    }
+
+    /// Set MMP configuration
+    ///
+    /// Configures Market Maker Protection (MMP) for a specific index.
+    /// Set interval to 0 to remove MMP configuration.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The MMP configuration request
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    /// use deribit_http::model::response::mmp::SetMmpConfigRequest;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let request = SetMmpConfigRequest {
+    /// //     index_name: "btc_usd".to_string(),
+    /// //     interval: 60,
+    /// //     frozen_time: 0,
+    /// //     quantity_limit: Some(3.0),
+    /// //     max_quote_quantity: Some(2.5),
+    /// //     ..Default::default()
+    /// // };
+    /// // let config = client.set_mmp_config(request).await?;
+    /// ```
+    pub async fn set_mmp_config(
+        &self,
+        request: SetMmpConfigRequest,
+    ) -> Result<MmpConfig, HttpError> {
+        let mut query_params = vec![
+            ("index_name".to_string(), request.index_name),
+            ("interval".to_string(), request.interval.to_string()),
+            ("frozen_time".to_string(), request.frozen_time.to_string()),
+        ];
+
+        if let Some(quantity_limit) = request.quantity_limit {
+            query_params.push(("quantity_limit".to_string(), quantity_limit.to_string()));
+        }
+
+        if let Some(delta_limit) = request.delta_limit {
+            query_params.push(("delta_limit".to_string(), delta_limit.to_string()));
+        }
+
+        if let Some(vega_limit) = request.vega_limit {
+            query_params.push(("vega_limit".to_string(), vega_limit.to_string()));
+        }
+
+        if let Some(max_quote_quantity) = request.max_quote_quantity {
+            query_params.push((
+                "max_quote_quantity".to_string(),
+                max_quote_quantity.to_string(),
+            ));
+        }
+
+        if let Some(mmp_group) = request.mmp_group {
+            query_params.push(("mmp_group".to_string(), mmp_group));
+        }
+
+        if let Some(block_rfq) = request.block_rfq
+            && block_rfq
+        {
+            query_params.push(("block_rfq".to_string(), "true".to_string()));
+        }
+
+        let query_string = query_params
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
+            .collect::<Vec<_>>()
+            .join("&");
+
+        let url = format!("{}{}?{}", self.base_url(), SET_MMP_CONFIG, query_string);
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Set MMP config failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<MmpConfig> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No MMP config data in response".to_string()))
+    }
+
+    /// Reset MMP limits
+    ///
+    /// Resets Market Maker Protection (MMP) limits for the specified currency pair or MMP group.
+    /// If MMP protection has been triggered and quoting is frozen, this allows manual resume.
+    ///
+    /// # Arguments
+    ///
+    /// * `index_name` - Currency pair (e.g., "btc_usd", "eth_usd")
+    /// * `mmp_group` - MMP group name for Mass Quotes, optional
+    /// * `block_rfq` - If true, reset MMP for Block RFQ, optional
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let result = client.reset_mmp("btc_usd", None, None).await?;
+    /// ```
+    pub async fn reset_mmp(
+        &self,
+        index_name: &str,
+        mmp_group: Option<&str>,
+        block_rfq: Option<bool>,
+    ) -> Result<String, HttpError> {
+        let mut query_params = vec![("index_name".to_string(), index_name.to_string())];
+
+        if let Some(group) = mmp_group {
+            query_params.push(("mmp_group".to_string(), group.to_string()));
+        }
+
+        if let Some(rfq) = block_rfq
+            && rfq
+        {
+            query_params.push(("block_rfq".to_string(), "true".to_string()));
+        }
+
+        let query_string = query_params
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
+            .collect::<Vec<_>>()
+            .join("&");
+
+        let url = format!("{}{}?{}", self.base_url(), RESET_MMP, query_string);
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Reset MMP failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<String> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No result in response".to_string()))
     }
 
     /// Mass quote

--- a/src/model/response/mmp.rs
+++ b/src/model/response/mmp.rs
@@ -1,0 +1,75 @@
+/******************************************************************************
+   Author: Joaquín Béjar García
+   Email: jb@taunais.com
+   Date: 7/3/26
+******************************************************************************/
+use pretty_simple_display::{DebugPretty, DisplaySimple};
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+/// Market Maker Protection (MMP) configuration
+///
+/// Contains the MMP parameters for a specific index and optional MMP group.
+#[skip_serializing_none]
+#[derive(DebugPretty, DisplaySimple, Clone, Serialize, Deserialize)]
+pub struct MmpConfig {
+    /// Index identifier (e.g., "btc_usd", "eth_usd")
+    pub index_name: String,
+    /// MMP group name (for Mass Quotes)
+    pub mmp_group: Option<String>,
+    /// Monitoring window duration in seconds
+    pub interval: u32,
+    /// Time in seconds that MMP remains active after being triggered
+    /// (0 = manual reset required)
+    pub frozen_time: u32,
+    /// Quantity limit for MMP
+    pub quantity_limit: Option<f64>,
+    /// Delta limit for MMP
+    pub delta_limit: Option<f64>,
+    /// Vega limit for MMP
+    pub vega_limit: Option<f64>,
+    /// Maximum quote quantity per side per order book
+    pub max_quote_quantity: Option<f64>,
+}
+
+/// Market Maker Protection (MMP) status
+///
+/// Contains the current MMP status for a triggered index or MMP group.
+#[skip_serializing_none]
+#[derive(DebugPretty, DisplaySimple, Clone, Serialize, Deserialize)]
+pub struct MmpStatus {
+    /// Index identifier (e.g., "btc_usd", "eth_usd")
+    pub index_name: String,
+    /// Timestamp (milliseconds since UNIX epoch) until the user is frozen
+    /// (0 = frozen until manual reset)
+    pub frozen_until: u64,
+    /// MMP group name (for Mass Quotes, optional)
+    pub mmp_group: Option<String>,
+}
+
+/// Request to set MMP configuration
+///
+/// Used to configure Market Maker Protection for a specific index.
+#[skip_serializing_none]
+#[derive(DebugPretty, DisplaySimple, Clone, Default, Serialize, Deserialize)]
+pub struct SetMmpConfigRequest {
+    /// Index identifier (e.g., "btc_usd", "eth_usd")
+    pub index_name: String,
+    /// Monitoring window duration in seconds (0 = remove MMP configuration)
+    pub interval: u32,
+    /// Time in seconds that MMP remains active after being triggered
+    /// (0 = manual reset required)
+    pub frozen_time: u32,
+    /// Quantity limit for MMP
+    pub quantity_limit: Option<f64>,
+    /// Delta limit for MMP
+    pub delta_limit: Option<f64>,
+    /// Vega limit for MMP
+    pub vega_limit: Option<f64>,
+    /// Maximum quote quantity per side per order book (required)
+    pub max_quote_quantity: Option<f64>,
+    /// MMP group name (for Mass Quotes)
+    pub mmp_group: Option<String>,
+    /// If true, configure MMP for Block RFQ
+    pub block_rfq: Option<bool>,
+}

--- a/src/model/response/mod.rs
+++ b/src/model/response/mod.rs
@@ -11,6 +11,8 @@ pub mod deposit;
 pub mod margin;
 /// Mass quote response models
 pub mod mass_quote;
+/// MMP response models
+pub mod mmp;
 /// Order response models and types
 pub mod order;
 /// Other response models and utilities
@@ -24,6 +26,7 @@ pub use api_response::*;
 pub use deposit::*;
 pub use margin::*;
 pub use mass_quote::*;
+pub use mmp::*;
 pub use order::*;
 pub use other::*;
 pub use trade::*;

--- a/tests/integration/order_management/mod.rs
+++ b/tests/integration/order_management/mod.rs
@@ -234,3 +234,86 @@ mod get_margins_tests {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod mmp_tests {
+    use deribit_http::DeribitHttpClient;
+    use tokio::time::{Duration, Instant};
+    use tracing::info;
+
+    /// Test get_mmp_config endpoint behavior
+    ///
+    /// Returns MMP configuration for an index.
+    #[tokio::test]
+    #[serial_test::serial]
+    #[ignore = "Requires authentication"]
+    async fn test_get_mmp_config() -> Result<(), Box<dyn std::error::Error>> {
+        let client = DeribitHttpClient::new();
+
+        info!("Testing get_mmp_config");
+        let start_time = Instant::now();
+
+        let result = client.get_mmp_config(Some("btc_usd"), None, None).await;
+        let elapsed = start_time.elapsed();
+
+        match &result {
+            Ok(configs) => {
+                info!(
+                    "Get MMP config succeeded in {:?}: {} configs found",
+                    elapsed,
+                    configs.len()
+                );
+            }
+            Err(e) => {
+                info!("Get MMP config failed in {:?}: {:?}", elapsed, e);
+            }
+        }
+
+        assert!(
+            elapsed < Duration::from_secs(30),
+            "Request took too long: {:?}",
+            elapsed
+        );
+
+        info!("test_get_mmp_config completed");
+        Ok(())
+    }
+
+    /// Test get_mmp_status endpoint behavior
+    ///
+    /// Returns MMP status for triggered indexes.
+    #[tokio::test]
+    #[serial_test::serial]
+    #[ignore = "Requires authentication"]
+    async fn test_get_mmp_status() -> Result<(), Box<dyn std::error::Error>> {
+        let client = DeribitHttpClient::new();
+
+        info!("Testing get_mmp_status");
+        let start_time = Instant::now();
+
+        let result = client.get_mmp_status(None, None, None).await;
+        let elapsed = start_time.elapsed();
+
+        match &result {
+            Ok(statuses) => {
+                info!(
+                    "Get MMP status succeeded in {:?}: {} statuses found",
+                    elapsed,
+                    statuses.len()
+                );
+            }
+            Err(e) => {
+                info!("Get MMP status failed in {:?}: {:?}", elapsed, e);
+            }
+        }
+
+        assert!(
+            elapsed < Duration::from_secs(30),
+            "Request took too long: {:?}",
+            elapsed
+        );
+
+        info!("test_get_mmp_status completed");
+        Ok(())
+    }
+}

--- a/tests/unit/private_endpoints_tests.rs
+++ b/tests/unit/private_endpoints_tests.rs
@@ -830,3 +830,168 @@ async fn test_get_margins_error() {
     mock.assert_async().await;
     assert!(result.is_err());
 }
+
+// =========================================================================
+// MMP Endpoints Tests (Issue #16)
+// =========================================================================
+
+#[tokio::test]
+async fn test_get_mmp_config_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": [
+            {
+                "index_name": "btc_usd",
+                "mmp_group": "MassQuoteBot7",
+                "interval": 60,
+                "frozen_time": 0,
+                "quantity_limit": 0.5,
+                "delta_limit": 0.3,
+                "vega_limit": 0.1,
+                "max_quote_quantity": 0.4
+            }
+        ],
+        "id": 1
+    });
+
+    let mock = server
+        .mock("GET", "/api/v2/private/get_mmp_config?index_name=btc_usd")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.get_mmp_config(Some("btc_usd"), None, None).await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let configs = result.unwrap();
+    assert_eq!(configs.len(), 1);
+    assert_eq!(configs[0].index_name, "btc_usd");
+    assert_eq!(configs[0].interval, 60);
+}
+
+#[tokio::test]
+async fn test_get_mmp_status_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": [
+            {
+                "index_name": "btc_usd",
+                "frozen_until": 1744275841861u64,
+                "mmp_group": "MassQuoteBot7"
+            }
+        ],
+        "id": 1
+    });
+
+    let mock = server
+        .mock("GET", "/api/v2/private/get_mmp_status?index_name=btc_usd")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.get_mmp_status(Some("btc_usd"), None, None).await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let statuses = result.unwrap();
+    assert_eq!(statuses.len(), 1);
+    assert_eq!(statuses[0].index_name, "btc_usd");
+    assert_eq!(statuses[0].frozen_until, 1744275841861);
+}
+
+#[tokio::test]
+async fn test_set_mmp_config_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": {
+            "index_name": "btc_usd",
+            "mmp_group": "MassQuoteBot7",
+            "interval": 60,
+            "frozen_time": 0,
+            "quantity_limit": 3.0,
+            "max_quote_quantity": 2.5
+        },
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(
+                r"/api/v2/private/set_mmp_config\?.*index_name=btc_usd.*".to_string(),
+            ),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let request = deribit_http::model::response::mmp::SetMmpConfigRequest {
+        index_name: "btc_usd".to_string(),
+        interval: 60,
+        frozen_time: 0,
+        quantity_limit: Some(3.0),
+        delta_limit: None,
+        vega_limit: None,
+        max_quote_quantity: Some(2.5),
+        mmp_group: Some("MassQuoteBot7".to_string()),
+        block_rfq: None,
+    };
+
+    let result = client.set_mmp_config(request).await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let config = result.unwrap();
+    assert_eq!(config.index_name, "btc_usd");
+    assert_eq!(config.interval, 60);
+}
+
+#[tokio::test]
+async fn test_reset_mmp_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": "ok",
+        "id": 1
+    });
+
+    let mock = server
+        .mock("GET", "/api/v2/private/reset_mmp?index_name=btc_usd")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.reset_mmp("btc_usd", None, None).await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "ok");
+}


### PR DESCRIPTION
## Summary

Implement the 4 Market Maker Protection (MMP) endpoints for the HTTP client.

## Endpoints Implemented

| Endpoint | Method | Description |
|----------|--------|-------------|
| `get_mmp_config` | `get_mmp_config(index_name?, mmp_group?, block_rfq?)` | Get MMP configuration |
| `get_mmp_status` | `get_mmp_status(index_name?, mmp_group?, block_rfq?)` | Get MMP status (triggered) |
| `set_mmp_config` | `set_mmp_config(request)` | Set MMP configuration |
| `reset_mmp` | `reset_mmp(index_name, mmp_group?, block_rfq?)` | Reset MMP limits |

## Changes

- Add 4 MMP endpoint constants in `src/constants.rs`
- Create `MmpConfig`, `MmpStatus`, `SetMmpConfigRequest` models in `src/model/response/mmp.rs`
- Implement 4 MMP methods in `src/endpoints/private.rs`
- Add 4 unit tests with mock server
- Add 2 integration tests (ignored by default, require authentication)

## New Models

```rust
pub struct MmpConfig {
    pub index_name: String,
    pub mmp_group: Option<String>,
    pub interval: u32,
    pub frozen_time: u32,
    pub quantity_limit: Option<f64>,
    pub delta_limit: Option<f64>,
    pub vega_limit: Option<f64>,
    pub max_quote_quantity: Option<f64>,
}

pub struct MmpStatus {
    pub index_name: String,
    pub frozen_until: u64,
    pub mmp_group: Option<String>,
}

pub struct SetMmpConfigRequest { ... }
```

## Testing

- [x] Unit tests added (4 tests: get_mmp_config, get_mmp_status, set_mmp_config, reset_mmp)
- [x] Integration tests added (2 tests, ignored by default)
- [x] Manual testing performed (`cargo test --all-features`)
- [x] Doc-tests pass (4 tests)

## Checklist

- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] No `.unwrap()`, `.expect()`, or panics in library code
- [x] HTTP error handling implemented
- [x] New models created with proper serde attributes

Closes #16
