### PR TITLE
M1 #17: Implement private/get_order_margin_by_ids endpoint

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -132,6 +132,8 @@ pub mod endpoints {
     pub const SET_MMP_CONFIG: &str = "/private/set_mmp_config";
     /// Reset MMP limits
     pub const RESET_MMP: &str = "/private/reset_mmp";
+    /// Get order margin by IDs
+    pub const GET_ORDER_MARGIN_BY_IDS: &str = "/private/get_order_margin_by_ids";
 
     // Private account endpoints
     /// Get account summary information

--- a/src/endpoints/private.rs
+++ b/src/endpoints/private.rs
@@ -10,7 +10,7 @@ use crate::model::request::order::OrderRequest;
 use crate::model::request::trade::TradesRequest;
 use crate::model::response::api_response::ApiResponse;
 use crate::model::response::deposit::DepositsResponse;
-use crate::model::response::margin::MarginsResponse;
+use crate::model::response::margin::{MarginsResponse, OrderMargin};
 use crate::model::response::mass_quote::MassQuoteResponse;
 use crate::model::response::mmp::{MmpConfig, MmpStatus, SetMmpConfigRequest};
 use crate::model::response::order::{OrderInfoResponse, OrderResponse};
@@ -1598,6 +1598,76 @@ impl DeribitHttpClient {
         api_response
             .result
             .ok_or_else(|| HttpError::InvalidResponse("No margin data in response".to_string()))
+    }
+
+    /// Get order margin by IDs
+    ///
+    /// Retrieves the initial margin requirements for one or more orders identified
+    /// by their order IDs. Initial margin is the amount of funds required to open
+    /// a position with these orders.
+    ///
+    /// # Arguments
+    ///
+    /// * `ids` - Array of order IDs (e.g., ["ETH-349280", "ETH-349279"])
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let margins = client.get_order_margin_by_ids(&["ETH-349280", "ETH-349279"]).await?;
+    /// ```
+    pub async fn get_order_margin_by_ids(
+        &self,
+        ids: &[&str],
+    ) -> Result<Vec<OrderMargin>, HttpError> {
+        if ids.is_empty() {
+            return Err(HttpError::RequestFailed(
+                "ids array cannot be empty".to_string(),
+            ));
+        }
+
+        // Format IDs as JSON array for the query parameter
+        let ids_json = serde_json::to_string(ids)
+            .map_err(|e| HttpError::InvalidResponse(format!("Failed to serialize ids: {}", e)))?;
+
+        let query_string = format!("ids={}", urlencoding::encode(&ids_json));
+        let url = format!(
+            "{}{}?{}",
+            self.base_url(),
+            GET_ORDER_MARGIN_BY_IDS,
+            query_string
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get order margin by IDs failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<Vec<OrderMargin>> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response.result.ok_or_else(|| {
+            HttpError::InvalidResponse("No order margin data in response".to_string())
+        })
     }
 
     /// Get MMP configuration

--- a/src/model/response/margin.rs
+++ b/src/model/response/margin.rs
@@ -23,3 +23,16 @@ pub struct MarginsResponse {
     /// this price will be clamped to this maximum.
     pub max_price: f64,
 }
+
+/// Response from the get_order_margin_by_ids endpoint
+///
+/// Contains initial margin requirements for an order identified by its ID.
+#[derive(DebugPretty, DisplaySimple, Clone, Serialize, Deserialize)]
+pub struct OrderMargin {
+    /// Unique order identifier
+    pub order_id: String,
+    /// Initial margin required for the order
+    pub initial_margin: f64,
+    /// Currency of the initial margin
+    pub initial_margin_currency: String,
+}

--- a/tests/integration/order_management/mod.rs
+++ b/tests/integration/order_management/mod.rs
@@ -317,3 +317,57 @@ mod mmp_tests {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod get_order_margin_by_ids_tests {
+    use deribit_http::DeribitHttpClient;
+    use tokio::time::{Duration, Instant};
+    use tracing::info;
+
+    /// Test get_order_margin_by_ids endpoint behavior
+    ///
+    /// Returns initial margin requirements for orders by their IDs.
+    #[tokio::test]
+    #[serial_test::serial]
+    #[ignore = "Requires authentication and valid order IDs"]
+    async fn test_get_order_margin_by_ids() -> Result<(), Box<dyn std::error::Error>> {
+        let client = DeribitHttpClient::new();
+
+        info!("Testing get_order_margin_by_ids");
+        let start_time = Instant::now();
+
+        // Note: This test requires valid order IDs that exist in the account
+        let result = client
+            .get_order_margin_by_ids(&["ETH-349280", "ETH-349279"])
+            .await;
+        let elapsed = start_time.elapsed();
+
+        match &result {
+            Ok(margins) => {
+                info!(
+                    "Get order margin by IDs succeeded in {:?}: {} margins found",
+                    elapsed,
+                    margins.len()
+                );
+                for margin in margins {
+                    info!(
+                        "Order {}: initial_margin={} {}",
+                        margin.order_id, margin.initial_margin, margin.initial_margin_currency
+                    );
+                }
+            }
+            Err(e) => {
+                info!("Get order margin by IDs failed in {:?}: {:?}", elapsed, e);
+            }
+        }
+
+        assert!(
+            elapsed < Duration::from_secs(30),
+            "Request took too long: {:?}",
+            elapsed
+        );
+
+        info!("test_get_order_margin_by_ids completed");
+        Ok(())
+    }
+}

--- a/tests/unit/private_endpoints_tests.rs
+++ b/tests/unit/private_endpoints_tests.rs
@@ -995,3 +995,67 @@ async fn test_reset_mmp_success() {
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), "ok");
 }
+
+// =========================================================================
+// Get Order Margin By IDs Tests (Issue #17)
+// =========================================================================
+
+#[tokio::test]
+async fn test_get_order_margin_by_ids_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": [
+            {
+                "order_id": "ETH-349278",
+                "initial_margin": 0.00091156,
+                "initial_margin_currency": "ETH"
+            },
+            {
+                "order_id": "ETH-349279",
+                "initial_margin": 0.0,
+                "initial_margin_currency": "ETH"
+            }
+        ],
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(r"/api/v2/private/get_order_margin_by_ids\?ids=.*".to_string()),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client
+        .get_order_margin_by_ids(&["ETH-349278", "ETH-349279"])
+        .await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let margins = result.unwrap();
+    assert_eq!(margins.len(), 2);
+    assert_eq!(margins[0].order_id, "ETH-349278");
+    assert!((margins[0].initial_margin - 0.00091156).abs() < 0.0001);
+    assert_eq!(margins[0].initial_margin_currency, "ETH");
+}
+
+#[tokio::test]
+async fn test_get_order_margin_by_ids_empty_ids_error() {
+    let server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let result = client.get_order_margin_by_ids(&[]).await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.to_string().contains("ids array cannot be empty"));
+}


### PR DESCRIPTION
## Summary

Implement the `private/get_order_margin_by_ids` endpoint that retrieves initial margin requirements for orders by their IDs.

## Changes

- Add `GET_ORDER_MARGIN_BY_IDS` constant in `src/constants.rs`
- Add `OrderMargin` struct in `src/model/response/margin.rs`
- Implement `get_order_margin_by_ids(ids)` method in `src/endpoints/private.rs`
- Add 2 unit tests with mock server
- Add 1 integration test (ignored by default, requires authentication and valid order IDs)

## API

```rust
pub async fn get_order_margin_by_ids(
    &self,
    ids: &[&str],
) -> Result<Vec<OrderMargin>, HttpError>
```

### Response Model

```rust
pub struct OrderMargin {
    pub order_id: String,
    pub initial_margin: f64,
    pub initial_margin_currency: String,
}
```

## Testing

- [x] Unit tests added (2 tests: success, empty IDs error)
- [x] Integration test added (1 test, ignored by default)
- [x] Manual testing performed (`cargo test --all-features`)
- [x] Doc-test passes

## Checklist

- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] No `.unwrap()`, `.expect()`, or panics in library code
- [x] HTTP error handling implemented
- [x] Input validation (empty IDs array check)

Closes #17
