### PR TITLE
M1 #18: Implement private/get_order_state_by_label endpoint

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -134,6 +134,8 @@ pub mod endpoints {
     pub const RESET_MMP: &str = "/private/reset_mmp";
     /// Get order margin by IDs
     pub const GET_ORDER_MARGIN_BY_IDS: &str = "/private/get_order_margin_by_ids";
+    /// Get order state by label
+    pub const GET_ORDER_STATE_BY_LABEL: &str = "/private/get_order_state_by_label";
 
     // Private account endpoints
     /// Get account summary information

--- a/src/endpoints/private.rs
+++ b/src/endpoints/private.rs
@@ -1670,6 +1670,79 @@ impl DeribitHttpClient {
         })
     }
 
+    /// Get order state by label
+    ///
+    /// Retrieves the state of recent orders that have a specific label.
+    /// Results are filtered by currency and label. The response includes
+    /// order details such as status, filled amount, remaining amount, and
+    /// other order properties for all orders with the specified label.
+    ///
+    /// # Arguments
+    ///
+    /// * `currency` - Currency symbol (e.g., "BTC", "ETH", "USDC")
+    /// * `label` - User-defined label (max 64 characters)
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let orders = client.get_order_state_by_label("ETH", "myLabel").await?;
+    /// ```
+    pub async fn get_order_state_by_label(
+        &self,
+        currency: &str,
+        label: &str,
+    ) -> Result<Vec<OrderInfoResponse>, HttpError> {
+        let query_params = [
+            ("currency".to_string(), currency.to_string()),
+            ("label".to_string(), label.to_string()),
+        ];
+
+        let query_string = query_params
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
+            .collect::<Vec<_>>()
+            .join("&");
+
+        let url = format!(
+            "{}{}?{}",
+            self.base_url(),
+            GET_ORDER_STATE_BY_LABEL,
+            query_string
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get order state by label failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<Vec<OrderInfoResponse>> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No order data in response".to_string()))
+    }
+
     /// Get MMP configuration
     ///
     /// Retrieves Market Maker Protection (MMP) configuration for an index.

--- a/tests/integration/order_management/mod.rs
+++ b/tests/integration/order_management/mod.rs
@@ -371,3 +371,54 @@ mod get_order_margin_by_ids_tests {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod get_order_state_by_label_tests {
+    use deribit_http::DeribitHttpClient;
+    use tokio::time::{Duration, Instant};
+    use tracing::info;
+
+    /// Test get_order_state_by_label endpoint behavior
+    ///
+    /// Returns order states for orders with a specific label.
+    #[tokio::test]
+    #[serial_test::serial]
+    #[ignore = "Requires authentication"]
+    async fn test_get_order_state_by_label() -> Result<(), Box<dyn std::error::Error>> {
+        let client = DeribitHttpClient::new();
+
+        info!("Testing get_order_state_by_label");
+        let start_time = Instant::now();
+
+        let result = client.get_order_state_by_label("ETH", "testLabel").await;
+        let elapsed = start_time.elapsed();
+
+        match &result {
+            Ok(orders) => {
+                info!(
+                    "Get order state by label succeeded in {:?}: {} orders found",
+                    elapsed,
+                    orders.len()
+                );
+                for order in orders {
+                    info!(
+                        "Order {}: state={}, instrument={}",
+                        order.order_id, order.order_state, order.instrument_name
+                    );
+                }
+            }
+            Err(e) => {
+                info!("Get order state by label failed in {:?}: {:?}", elapsed, e);
+            }
+        }
+
+        assert!(
+            elapsed < Duration::from_secs(30),
+            "Request took too long: {:?}",
+            elapsed
+        );
+
+        info!("test_get_order_state_by_label completed");
+        Ok(())
+    }
+}

--- a/tests/unit/private_endpoints_tests.rs
+++ b/tests/unit/private_endpoints_tests.rs
@@ -1059,3 +1059,98 @@ async fn test_get_order_margin_by_ids_empty_ids_error() {
     let err = result.unwrap_err();
     assert!(err.to_string().contains("ids array cannot be empty"));
 }
+
+// =========================================================================
+// Get Order State By Label Tests (Issue #18)
+// =========================================================================
+
+#[tokio::test]
+async fn test_get_order_state_by_label_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": [
+            {
+                "time_in_force": "good_til_cancelled",
+                "reduce_only": false,
+                "price": 118.94,
+                "post_only": false,
+                "order_type": "limit",
+                "order_state": "filled",
+                "order_id": "ETH-331562",
+                "max_show": 37.0,
+                "last_update_timestamp": 1550219810944u64,
+                "label": "fooBar",
+                "is_liquidation": false,
+                "instrument_name": "ETH-PERPETUAL",
+                "filled_amount": 37.0,
+                "direction": "sell",
+                "creation_timestamp": 1550219749176u64,
+                "average_price": 118.94,
+                "api": false,
+                "amount": 37.0,
+                "replaced": false,
+                "risk_reducing": false,
+                "web": false
+            }
+        ],
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            "/api/v2/private/get_order_state_by_label?currency=ETH&label=fooBar",
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.get_order_state_by_label("ETH", "fooBar").await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let orders = result.unwrap();
+    assert_eq!(orders.len(), 1);
+    assert_eq!(orders[0].order_id, "ETH-331562");
+    assert_eq!(orders[0].order_state, "filled");
+    assert_eq!(orders[0].label, "fooBar");
+}
+
+#[tokio::test]
+async fn test_get_order_state_by_label_empty_result() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": [],
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            "/api/v2/private/get_order_state_by_label?currency=BTC&label=nonexistent",
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.get_order_state_by_label("BTC", "nonexistent").await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let orders = result.unwrap();
+    assert!(orders.is_empty());
+}


### PR DESCRIPTION
## Summary

Implement the `private/get_order_state_by_label` endpoint that retrieves the state of recent orders with a specific label, filtered by currency.

## Changes

- Add `GET_ORDER_STATE_BY_LABEL` constant in `src/constants.rs`
- Implement `get_order_state_by_label(currency, label)` method in `src/endpoints/private.rs`
- Uses existing `OrderInfoResponse` model — no new model needed
- Add 2 unit tests with mock server
- Add 1 integration test (ignored by default, requires authentication)

## API

```rust
pub async fn get_order_state_by_label(
    &self,
    currency: &str,
    label: &str,
) -> Result<Vec<OrderInfoResponse>, HttpError>
```

### Parameters
- `currency` - Currency symbol (e.g., "BTC", "ETH", "USDC")
- `label` - User-defined label (max 64 characters)

## Testing

- [x] Unit tests added (2 tests: success, empty result)
- [x] Integration test added (1 test, ignored by default)
- [x] Manual testing performed (`cargo test --all-features`)
- [x] Doc-test passes

## Checklist

- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] No `.unwrap()`, `.expect()`, or panics in library code
- [x] HTTP error handling implemented
- [x] Uses existing model (OrderInfoResponse)

Closes #18
