### PR TITLE
M1 #19: Implement private settlement history endpoints

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -136,6 +136,12 @@ pub mod endpoints {
     pub const GET_ORDER_MARGIN_BY_IDS: &str = "/private/get_order_margin_by_ids";
     /// Get order state by label
     pub const GET_ORDER_STATE_BY_LABEL: &str = "/private/get_order_state_by_label";
+    /// Get settlement history by currency
+    pub const GET_SETTLEMENT_HISTORY_BY_CURRENCY: &str =
+        "/private/get_settlement_history_by_currency";
+    /// Get settlement history by instrument
+    pub const GET_SETTLEMENT_HISTORY_BY_INSTRUMENT: &str =
+        "/private/get_settlement_history_by_instrument";
 
     // Private account endpoints
     /// Get account summary information

--- a/src/endpoints/private.rs
+++ b/src/endpoints/private.rs
@@ -15,7 +15,7 @@ use crate::model::response::mass_quote::MassQuoteResponse;
 use crate::model::response::mmp::{MmpConfig, MmpStatus, SetMmpConfigRequest};
 use crate::model::response::order::{OrderInfoResponse, OrderResponse};
 use crate::model::response::other::{
-    AccountSummaryResponse, TransactionLogResponse, TransferResultResponse,
+    AccountSummaryResponse, SettlementsResponse, TransactionLogResponse, TransferResultResponse,
 };
 use crate::model::response::withdrawal::WithdrawalsResponse;
 use crate::model::{
@@ -1741,6 +1741,184 @@ impl DeribitHttpClient {
         api_response
             .result
             .ok_or_else(|| HttpError::InvalidResponse("No order data in response".to_string()))
+    }
+
+    /// Get settlement history by currency
+    ///
+    /// Retrieves settlement, delivery, and bankruptcy events that have affected
+    /// your account for a specific currency. Settlements occur when futures or
+    /// options contracts expire and are settled at the delivery price.
+    ///
+    /// # Arguments
+    ///
+    /// * `currency` - Currency symbol (e.g., "BTC", "ETH", "USDC")
+    /// * `settlement_type` - Settlement type: "settlement", "delivery", or "bankruptcy" (optional)
+    /// * `count` - Number of items (default 20, max 1000) (optional)
+    /// * `continuation` - Pagination token (optional)
+    /// * `search_start_timestamp` - Latest timestamp to return results from in ms (optional)
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let history = client.get_settlement_history_by_currency("BTC", None, None, None, None).await?;
+    /// ```
+    pub async fn get_settlement_history_by_currency(
+        &self,
+        currency: &str,
+        settlement_type: Option<&str>,
+        count: Option<u32>,
+        continuation: Option<&str>,
+        search_start_timestamp: Option<u64>,
+    ) -> Result<SettlementsResponse, HttpError> {
+        let mut url = format!(
+            "{}{}?currency={}",
+            self.base_url(),
+            GET_SETTLEMENT_HISTORY_BY_CURRENCY,
+            urlencoding::encode(currency)
+        );
+
+        if let Some(settlement_type) = settlement_type {
+            url.push_str(&format!("&type={}", urlencoding::encode(settlement_type)));
+        }
+
+        if let Some(count) = count {
+            url.push_str(&format!("&count={}", count));
+        }
+
+        if let Some(continuation) = continuation {
+            url.push_str(&format!(
+                "&continuation={}",
+                urlencoding::encode(continuation)
+            ));
+        }
+
+        if let Some(search_start_timestamp) = search_start_timestamp {
+            url.push_str(&format!(
+                "&search_start_timestamp={}",
+                search_start_timestamp
+            ));
+        }
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get settlement history by currency failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<SettlementsResponse> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No settlement data in response".to_string()))
+    }
+
+    /// Get settlement history by instrument
+    ///
+    /// Retrieves settlement, delivery, and bankruptcy events for a specific
+    /// instrument that have affected your account. Settlements occur when futures
+    /// or options contracts expire and are settled at the delivery price.
+    ///
+    /// # Arguments
+    ///
+    /// * `instrument_name` - Instrument identifier (e.g., "BTC-PERPETUAL")
+    /// * `settlement_type` - Settlement type: "settlement", "delivery", or "bankruptcy" (optional)
+    /// * `count` - Number of items (default 20, max 1000) (optional)
+    /// * `continuation` - Pagination token (optional)
+    /// * `search_start_timestamp` - Latest timestamp to return results from in ms (optional)
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let history = client.get_settlement_history_by_instrument("BTC-PERPETUAL", None, None, None, None).await?;
+    /// ```
+    pub async fn get_settlement_history_by_instrument(
+        &self,
+        instrument_name: &str,
+        settlement_type: Option<&str>,
+        count: Option<u32>,
+        continuation: Option<&str>,
+        search_start_timestamp: Option<u64>,
+    ) -> Result<SettlementsResponse, HttpError> {
+        let mut url = format!(
+            "{}{}?instrument_name={}",
+            self.base_url(),
+            GET_SETTLEMENT_HISTORY_BY_INSTRUMENT,
+            urlencoding::encode(instrument_name)
+        );
+
+        if let Some(settlement_type) = settlement_type {
+            url.push_str(&format!("&type={}", urlencoding::encode(settlement_type)));
+        }
+
+        if let Some(count) = count {
+            url.push_str(&format!("&count={}", count));
+        }
+
+        if let Some(continuation) = continuation {
+            url.push_str(&format!(
+                "&continuation={}",
+                urlencoding::encode(continuation)
+            ));
+        }
+
+        if let Some(search_start_timestamp) = search_start_timestamp {
+            url.push_str(&format!(
+                "&search_start_timestamp={}",
+                search_start_timestamp
+            ));
+        }
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get settlement history by instrument failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<SettlementsResponse> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No settlement data in response".to_string()))
     }
 
     /// Get MMP configuration

--- a/tests/integration/account_management/mod.rs
+++ b/tests/integration/account_management/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod account_summary;
 pub mod positions;
+pub mod settlement_history;
 pub mod subaccounts;
 pub mod transaction_log;
 pub mod user_trades;

--- a/tests/integration/account_management/settlement_history.rs
+++ b/tests/integration/account_management/settlement_history.rs
@@ -1,0 +1,103 @@
+//! Settlement history integration tests
+//!
+//! Tests for private/get_settlement_history_by_currency and
+//! private/get_settlement_history_by_instrument endpoints.
+
+#[cfg(test)]
+mod settlement_history_tests {
+    use deribit_http::DeribitHttpClient;
+    use tokio::time::{Duration, Instant};
+    use tracing::info;
+
+    /// Test get_settlement_history_by_currency endpoint behavior
+    ///
+    /// Returns settlement, delivery, and bankruptcy events for a currency.
+    #[tokio::test]
+    #[serial_test::serial]
+    #[ignore = "Requires authentication"]
+    async fn test_get_settlement_history_by_currency() -> Result<(), Box<dyn std::error::Error>> {
+        let client = DeribitHttpClient::new();
+
+        info!("Testing get_settlement_history_by_currency");
+        let start_time = Instant::now();
+
+        let result = client
+            .get_settlement_history_by_currency("BTC", None, Some(10), None, None)
+            .await;
+        let elapsed = start_time.elapsed();
+
+        match &result {
+            Ok(response) => {
+                info!(
+                    "Get settlement history by currency succeeded in {:?}: {} settlements found",
+                    elapsed,
+                    response.settlements.len()
+                );
+                if let Some(continuation) = &response.continuation {
+                    info!("Continuation token: {}", continuation);
+                }
+            }
+            Err(e) => {
+                info!(
+                    "Get settlement history by currency failed in {:?}: {:?}",
+                    elapsed, e
+                );
+            }
+        }
+
+        assert!(
+            elapsed < Duration::from_secs(30),
+            "Request took too long: {:?}",
+            elapsed
+        );
+
+        info!("test_get_settlement_history_by_currency completed");
+        Ok(())
+    }
+
+    /// Test get_settlement_history_by_instrument endpoint behavior
+    ///
+    /// Returns settlement, delivery, and bankruptcy events for an instrument.
+    #[tokio::test]
+    #[serial_test::serial]
+    #[ignore = "Requires authentication"]
+    async fn test_get_settlement_history_by_instrument() -> Result<(), Box<dyn std::error::Error>> {
+        let client = DeribitHttpClient::new();
+
+        info!("Testing get_settlement_history_by_instrument");
+        let start_time = Instant::now();
+
+        let result = client
+            .get_settlement_history_by_instrument("BTC-PERPETUAL", None, Some(10), None, None)
+            .await;
+        let elapsed = start_time.elapsed();
+
+        match &result {
+            Ok(response) => {
+                info!(
+                    "Get settlement history by instrument succeeded in {:?}: {} settlements found",
+                    elapsed,
+                    response.settlements.len()
+                );
+                if let Some(continuation) = &response.continuation {
+                    info!("Continuation token: {}", continuation);
+                }
+            }
+            Err(e) => {
+                info!(
+                    "Get settlement history by instrument failed in {:?}: {:?}",
+                    elapsed, e
+                );
+            }
+        }
+
+        assert!(
+            elapsed < Duration::from_secs(30),
+            "Request took too long: {:?}",
+            elapsed
+        );
+
+        info!("test_get_settlement_history_by_instrument completed");
+        Ok(())
+    }
+}

--- a/tests/unit/private_endpoints_tests.rs
+++ b/tests/unit/private_endpoints_tests.rs
@@ -1154,3 +1154,120 @@ async fn test_get_order_state_by_label_empty_result() {
     let orders = result.unwrap();
     assert!(orders.is_empty());
 }
+
+// =========================================================================
+// Get Settlement History By Currency Tests (Issue #19)
+// =========================================================================
+
+#[tokio::test]
+async fn test_get_settlement_history_by_currency_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": {
+            "settlements": [
+                {
+                    "type": "settlement",
+                    "timestamp": 1550475692526i64,
+                    "session_profit_loss": 0.038358299,
+                    "profit_loss": -0.001783937,
+                    "position": -66.0,
+                    "mark_price": 121.67,
+                    "instrument_name": "ETH-22FEB19",
+                    "index_price": 119.8
+                }
+            ],
+            "continuation": "xY7T6cusbMBNpH9SNmKb94jXSBxUPojJEdCPL4YociHBUgAhWQvEP"
+        },
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(
+                r"/api/v2/private/get_settlement_history_by_currency\?currency=BTC.*".to_string(),
+            ),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client
+        .get_settlement_history_by_currency("BTC", Some("settlement"), Some(1), None, None)
+        .await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let response = result.unwrap();
+    assert_eq!(response.settlements.len(), 1);
+    assert!(response.continuation.is_some());
+}
+
+// =========================================================================
+// Get Settlement History By Instrument Tests (Issue #19)
+// =========================================================================
+
+#[tokio::test]
+async fn test_get_settlement_history_by_instrument_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": {
+            "settlements": [
+                {
+                    "type": "settlement",
+                    "timestamp": 1550475692526i64,
+                    "session_profit_loss": 0.038358299,
+                    "profit_loss": -0.001783937,
+                    "position": -66.0,
+                    "mark_price": 121.67,
+                    "instrument_name": "ETH-22FEB19",
+                    "index_price": 119.8
+                }
+            ],
+            "continuation": "xY7T6cusbMBNpH9SNmKb94jXSBxUPojJEdCPL4YociHBUgAhWQvEP"
+        },
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(
+                r"/api/v2/private/get_settlement_history_by_instrument\?instrument_name=.*"
+                    .to_string(),
+            ),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client
+        .get_settlement_history_by_instrument(
+            "ETH-22FEB19",
+            Some("settlement"),
+            Some(1),
+            None,
+            None,
+        )
+        .await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let response = result.unwrap();
+    assert_eq!(response.settlements.len(), 1);
+    assert!(response.continuation.is_some());
+}


### PR DESCRIPTION
## Summary

Implement two private settlement history endpoints for retrieving settlement, delivery, and bankruptcy events that have affected the user's account.

## Endpoints

| Endpoint | Required Param | Description |
|----------|----------------|-------------|
| `private/get_settlement_history_by_currency` | `currency` | Filter by currency (BTC, ETH, etc.) |
| `private/get_settlement_history_by_instrument` | `instrument_name` | Filter by instrument |

## Changes

- Add `GET_SETTLEMENT_HISTORY_BY_CURRENCY` constant in `src/constants.rs`
- Add `GET_SETTLEMENT_HISTORY_BY_INSTRUMENT` constant in `src/constants.rs`
- Implement `get_settlement_history_by_currency()` method with pagination support
- Implement `get_settlement_history_by_instrument()` method with pagination support
- Uses existing `SettlementsResponse` model — no new model needed
- Add 2 unit tests with mock server
- Add 2 integration tests (ignored by default, requires authentication)

## API

```rust
pub async fn get_settlement_history_by_currency(
    &self,
    currency: &str,
    settlement_type: Option<&str>,
    count: Option<u32>,
    continuation: Option<&str>,
    search_start_timestamp: Option<u64>,
) -> Result<SettlementsResponse, HttpError>

pub async fn get_settlement_history_by_instrument(
    &self,
    instrument_name: &str,
    settlement_type: Option<&str>,
    count: Option<u32>,
    continuation: Option<&str>,
    search_start_timestamp: Option<u64>,
) -> Result<SettlementsResponse, HttpError>
```

## Testing

- [x] Unit tests added (2 tests, one per endpoint)
- [x] Integration tests added (2 tests, ignored by default)
- [x] Manual testing performed (`cargo test --all-features`)
- [x] Doc-tests pass

## Checklist

- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] No `.unwrap()`, `.expect()`, or panics in library code
- [x] HTTP error handling implemented
- [x] Uses existing model (SettlementsResponse)
- [x] Pagination support implemented

Closes #19
