### PR TITLE
M1 #20: Implement private/get_trigger_order_history endpoint

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -142,6 +142,8 @@ pub mod endpoints {
     /// Get settlement history by instrument
     pub const GET_SETTLEMENT_HISTORY_BY_INSTRUMENT: &str =
         "/private/get_settlement_history_by_instrument";
+    /// Get trigger order history
+    pub const GET_TRIGGER_ORDER_HISTORY: &str = "/private/get_trigger_order_history";
 
     // Private account endpoints
     /// Get account summary information

--- a/src/endpoints/private.rs
+++ b/src/endpoints/private.rs
@@ -17,6 +17,7 @@ use crate::model::response::order::{OrderInfoResponse, OrderResponse};
 use crate::model::response::other::{
     AccountSummaryResponse, SettlementsResponse, TransactionLogResponse, TransferResultResponse,
 };
+use crate::model::response::trigger::TriggerOrderHistoryResponse;
 use crate::model::response::withdrawal::WithdrawalsResponse;
 use crate::model::{
     TransactionLogRequest, UserTradeResponseByOrder, UserTradeWithPaginationResponse,
@@ -1919,6 +1920,89 @@ impl DeribitHttpClient {
         api_response
             .result
             .ok_or_else(|| HttpError::InvalidResponse("No settlement data in response".to_string()))
+    }
+
+    /// Get trigger order history
+    ///
+    /// Retrieves a detailed log of all trigger orders (stop orders, take-profit orders, etc.)
+    /// for the authenticated account. The log includes trigger order creation, activation,
+    /// execution, and cancellation events.
+    ///
+    /// # Arguments
+    ///
+    /// * `currency` - Currency symbol (e.g., "BTC", "ETH", "USDC")
+    /// * `instrument_name` - Filter by specific instrument (optional)
+    /// * `count` - Number of items (default 20, max 1000) (optional)
+    /// * `continuation` - Pagination token (optional)
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let history = client.get_trigger_order_history("BTC", None, None, None).await?;
+    /// ```
+    pub async fn get_trigger_order_history(
+        &self,
+        currency: &str,
+        instrument_name: Option<&str>,
+        count: Option<u32>,
+        continuation: Option<&str>,
+    ) -> Result<TriggerOrderHistoryResponse, HttpError> {
+        let mut url = format!(
+            "{}{}?currency={}",
+            self.base_url(),
+            GET_TRIGGER_ORDER_HISTORY,
+            urlencoding::encode(currency)
+        );
+
+        if let Some(instrument_name) = instrument_name {
+            url.push_str(&format!(
+                "&instrument_name={}",
+                urlencoding::encode(instrument_name)
+            ));
+        }
+
+        if let Some(count) = count {
+            url.push_str(&format!("&count={}", count));
+        }
+
+        if let Some(continuation) = continuation {
+            url.push_str(&format!(
+                "&continuation={}",
+                urlencoding::encode(continuation)
+            ));
+        }
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get trigger order history failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<TriggerOrderHistoryResponse> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response.result.ok_or_else(|| {
+            HttpError::InvalidResponse("No trigger order history data in response".to_string())
+        })
     }
 
     /// Get MMP configuration

--- a/src/model/response/mod.rs
+++ b/src/model/response/mod.rs
@@ -19,6 +19,8 @@ pub mod order;
 pub mod other;
 /// Trade response models and types
 pub mod trade;
+/// Trigger order response models
+pub mod trigger;
 /// Withdrawal response models
 pub mod withdrawal;
 
@@ -30,4 +32,5 @@ pub use mmp::*;
 pub use order::*;
 pub use other::*;
 pub use trade::*;
+pub use trigger::*;
 pub use withdrawal::*;

--- a/src/model/response/trigger.rs
+++ b/src/model/response/trigger.rs
@@ -1,0 +1,161 @@
+/******************************************************************************
+   Author: Joaquín Béjar García
+   Email: jb@taunais.com
+   Date: 7/3/26
+******************************************************************************/
+//! Trigger order response models
+
+use pretty_simple_display::{DebugPretty, DisplaySimple};
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+/// A single entry in the trigger order history
+///
+/// Represents a trigger order event such as creation, activation,
+/// execution, or cancellation.
+#[skip_serializing_none]
+#[derive(DebugPretty, DisplaySimple, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TriggerOrderHistoryEntry {
+    /// Timestamp of the event in milliseconds since Unix epoch
+    pub timestamp: i64,
+    /// Trigger type: "index_price", "mark_price", or "last_price"
+    pub trigger: Option<String>,
+    /// Trigger price (only for future trigger orders)
+    pub trigger_price: Option<f64>,
+    /// Maximum deviation from price peak for trailing trigger orders
+    pub trigger_offset: Option<f64>,
+    /// ID of the trigger order before triggering
+    pub trigger_order_id: String,
+    /// Unique order identifier after triggering
+    pub order_id: Option<String>,
+    /// Order state: "triggered", "cancelled", or "rejected"
+    pub order_state: String,
+    /// Unique instrument identifier
+    pub instrument_name: String,
+    /// Type of last request: "cancel" or "trigger:order"
+    pub request: Option<String>,
+    /// Direction: "buy" or "sell"
+    pub direction: String,
+    /// Price in base currency
+    pub price: Option<f64>,
+    /// Order size (USD for perpetual/inverse, base currency for options/linear)
+    pub amount: f64,
+    /// True for reduce-only orders
+    pub reduce_only: Option<bool>,
+    /// True for post-only orders
+    pub post_only: Option<bool>,
+    /// Order type: "limit" or "market"
+    pub order_type: Option<String>,
+    /// User defined label
+    pub label: Option<String>,
+    /// True if order can be triggered by another order
+    pub linked_order_type: Option<String>,
+    /// Unique reference for OCO (one_cancels_others) pair
+    pub oco_ref: Option<String>,
+    /// Source of the order linked to trigger order
+    pub trigger_source: Option<String>,
+    /// Last update timestamp in milliseconds since Unix epoch
+    pub last_update_timestamp: Option<i64>,
+}
+
+/// Response from get_trigger_order_history endpoint
+///
+/// Contains a list of trigger order history entries and an optional
+/// continuation token for pagination.
+#[skip_serializing_none]
+#[derive(DebugPretty, DisplaySimple, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TriggerOrderHistoryResponse {
+    /// List of trigger order history entries
+    pub entries: Vec<TriggerOrderHistoryEntry>,
+    /// Continuation token for pagination
+    pub continuation: Option<String>,
+}
+
+impl TriggerOrderHistoryResponse {
+    /// Create a new trigger order history response
+    pub fn new(entries: Vec<TriggerOrderHistoryEntry>) -> Self {
+        Self {
+            entries,
+            continuation: None,
+        }
+    }
+
+    /// Create response with continuation token
+    pub fn with_continuation(entries: Vec<TriggerOrderHistoryEntry>, continuation: String) -> Self {
+        Self {
+            entries,
+            continuation: Some(continuation),
+        }
+    }
+
+    /// Check if there are more results
+    pub fn has_more(&self) -> bool {
+        self.continuation.is_some()
+    }
+
+    /// Get the number of entries
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Check if the response is empty
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+impl Default for TriggerOrderHistoryResponse {
+    fn default() -> Self {
+        Self::new(Vec::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_trigger_order_history_response_new() {
+        let response = TriggerOrderHistoryResponse::new(vec![]);
+        assert!(response.entries.is_empty());
+        assert!(response.continuation.is_none());
+        assert!(!response.has_more());
+    }
+
+    #[test]
+    fn test_trigger_order_history_response_with_continuation() {
+        let response =
+            TriggerOrderHistoryResponse::with_continuation(vec![], "token123".to_string());
+        assert!(response.entries.is_empty());
+        assert_eq!(response.continuation, Some("token123".to_string()));
+        assert!(response.has_more());
+    }
+
+    #[test]
+    fn test_trigger_order_history_entry_deserialization() {
+        let json = r#"{
+            "timestamp": 1555918941451,
+            "trigger": "index_price",
+            "trigger_price": 5285.0,
+            "trigger_order_id": "SLIS-103",
+            "order_id": "671473",
+            "order_state": "triggered",
+            "instrument_name": "BTC-PERPETUAL",
+            "request": "trigger:order",
+            "direction": "buy",
+            "price": 5179.28,
+            "amount": 10.0
+        }"#;
+
+        let entry: TriggerOrderHistoryEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.timestamp, 1555918941451);
+        assert_eq!(entry.trigger, Some("index_price".to_string()));
+        assert_eq!(entry.trigger_price, Some(5285.0));
+        assert_eq!(entry.trigger_order_id, "SLIS-103");
+        assert_eq!(entry.order_id, Some("671473".to_string()));
+        assert_eq!(entry.order_state, "triggered");
+        assert_eq!(entry.instrument_name, "BTC-PERPETUAL");
+        assert_eq!(entry.direction, "buy");
+        assert_eq!(entry.amount, 10.0);
+    }
+}

--- a/tests/integration/order_management/mod.rs
+++ b/tests/integration/order_management/mod.rs
@@ -422,3 +422,53 @@ mod get_order_state_by_label_tests {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod get_trigger_order_history_tests {
+    use deribit_http::DeribitHttpClient;
+    use tokio::time::{Duration, Instant};
+    use tracing::info;
+
+    /// Test get_trigger_order_history endpoint behavior
+    ///
+    /// Returns history of trigger orders (stop-loss, take-profit, etc.)
+    #[tokio::test]
+    #[serial_test::serial]
+    #[ignore = "Requires authentication"]
+    async fn test_get_trigger_order_history() -> Result<(), Box<dyn std::error::Error>> {
+        let client = DeribitHttpClient::new();
+
+        info!("Testing get_trigger_order_history");
+        let start_time = Instant::now();
+
+        let result = client
+            .get_trigger_order_history("BTC", None, Some(10), None)
+            .await;
+        let elapsed = start_time.elapsed();
+
+        match &result {
+            Ok(response) => {
+                info!(
+                    "Get trigger order history succeeded in {:?}: {} entries found",
+                    elapsed,
+                    response.entries.len()
+                );
+                if let Some(continuation) = &response.continuation {
+                    info!("Continuation token: {}", continuation);
+                }
+            }
+            Err(e) => {
+                info!("Get trigger order history failed in {:?}: {:?}", elapsed, e);
+            }
+        }
+
+        assert!(
+            elapsed < Duration::from_secs(30),
+            "Request took too long: {:?}",
+            elapsed
+        );
+
+        info!("test_get_trigger_order_history completed");
+        Ok(())
+    }
+}

--- a/tests/unit/private_endpoints_tests.rs
+++ b/tests/unit/private_endpoints_tests.rs
@@ -1271,3 +1271,102 @@ async fn test_get_settlement_history_by_instrument_success() {
     assert_eq!(response.settlements.len(), 1);
     assert!(response.continuation.is_some());
 }
+
+// =========================================================================
+// Get Trigger Order History Tests (Issue #20)
+// =========================================================================
+
+#[tokio::test]
+async fn test_get_trigger_order_history_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": {
+            "entries": [
+                {
+                    "timestamp": 1555918941451i64,
+                    "trigger": "index_price",
+                    "trigger_price": 5285.0,
+                    "trigger_order_id": "SLIS-103",
+                    "order_id": "671473",
+                    "order_state": "triggered",
+                    "instrument_name": "BTC-PERPETUAL",
+                    "request": "trigger:order",
+                    "direction": "buy",
+                    "price": 5179.28,
+                    "amount": 10.0
+                }
+            ],
+            "continuation": "1555918941451.SLIS-103"
+        },
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(
+                r"/api/v2/private/get_trigger_order_history\?currency=BTC.*".to_string(),
+            ),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client
+        .get_trigger_order_history("BTC", None, Some(10), None)
+        .await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let response = result.unwrap();
+    assert_eq!(response.entries.len(), 1);
+    assert!(response.continuation.is_some());
+    assert_eq!(response.entries[0].trigger_order_id, "SLIS-103");
+    assert_eq!(response.entries[0].direction, "buy");
+}
+
+#[tokio::test]
+async fn test_get_trigger_order_history_empty() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": {
+            "entries": []
+        },
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(
+                r"/api/v2/private/get_trigger_order_history\?currency=ETH.*".to_string(),
+            ),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client
+        .get_trigger_order_history("ETH", Some("ETH-PERPETUAL"), None, None)
+        .await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let response = result.unwrap();
+    assert!(response.entries.is_empty());
+    assert!(response.continuation.is_none());
+}


### PR DESCRIPTION
## Summary

Implement the `private/get_trigger_order_history` endpoint for retrieving history of trigger orders (stop-loss, take-profit, etc.) with pagination support.

## Endpoint

| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| `currency` | string | Yes | Currency symbol (BTC, ETH, USDC, etc.) |
| `instrument_name` | string | No | Filter by specific instrument |
| `count` | u32 | No | Number of items (default 20, max 1000) |
| `continuation` | string | No | Pagination token |

## Changes

- Add `GET_TRIGGER_ORDER_HISTORY` constant in `src/constants.rs`
- Create `src/model/response/trigger.rs` with:
  - `TriggerOrderHistoryEntry` struct with all API fields
  - `TriggerOrderHistoryResponse` struct with pagination support
- Add `pub mod trigger;` to `src/model/response/mod.rs`
- Implement `get_trigger_order_history()` method in `src/endpoints/private.rs`
- Add 2 unit tests (success with entries, empty response)
- Add 1 integration test (ignored, requires authentication)
- Add 3 model unit tests (response creation, continuation, deserialization)

## API

```rust
pub async fn get_trigger_order_history(
    &self,
    currency: &str,
    instrument_name: Option<&str>,
    count: Option<u32>,
    continuation: Option<&str>,
) -> Result<TriggerOrderHistoryResponse, HttpError>
```

## Response Model

```rust
pub struct TriggerOrderHistoryEntry {
    pub timestamp: i64,
    pub trigger: Option<String>,
    pub trigger_price: Option<f64>,
    pub trigger_order_id: String,
    pub order_id: Option<String>,
    pub order_state: String,
    pub instrument_name: String,
    pub direction: String,
    pub amount: f64,
    // ... and more optional fields
}

pub struct TriggerOrderHistoryResponse {
    pub entries: Vec<TriggerOrderHistoryEntry>,
    pub continuation: Option<String>,
}
```

## Testing

- [x] Unit tests added (2 endpoint tests + 3 model tests)
- [x] Integration test added (ignored by default)
- [x] Manual testing (`cargo test --all-features`)
- [x] Doc-tests pass

## Checklist

- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] No `.unwrap()`, `.expect()`, or panics in library code
- [x] HTTP error handling implemented
- [x] New response model created with serialization tests
- [x] Pagination support implemented

Closes #20
