### PR TITLE
M1 #21: Implement private/move_positions endpoint

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -164,6 +164,8 @@ pub mod endpoints {
     pub const SUBMIT_TRANSFER_TO_SUBACCOUNT: &str = "/private/submit_transfer_to_subaccount";
     /// Submit transfer to user
     pub const SUBMIT_TRANSFER_TO_USER: &str = "/private/submit_transfer_to_user";
+    /// Move positions between subaccounts
+    pub const MOVE_POSITIONS: &str = "/private/move_positions";
 
     // Private order endpoints
     /// Get all open orders

--- a/src/endpoints/private.rs
+++ b/src/endpoints/private.rs
@@ -7,6 +7,7 @@ use crate::model::account::Subaccount;
 use crate::model::position::Position;
 use crate::model::request::mass_quote::MassQuoteRequest;
 use crate::model::request::order::OrderRequest;
+use crate::model::request::position::MovePositionTrade;
 use crate::model::request::trade::TradesRequest;
 use crate::model::response::api_response::ApiResponse;
 use crate::model::response::deposit::DepositsResponse;
@@ -17,6 +18,7 @@ use crate::model::response::order::{OrderInfoResponse, OrderResponse};
 use crate::model::response::other::{
     AccountSummaryResponse, SettlementsResponse, TransactionLogResponse, TransferResultResponse,
 };
+use crate::model::response::position::MovePositionResult;
 use crate::model::response::trigger::TriggerOrderHistoryResponse;
 use crate::model::response::withdrawal::WithdrawalsResponse;
 use crate::model::{
@@ -2002,6 +2004,89 @@ impl DeribitHttpClient {
 
         api_response.result.ok_or_else(|| {
             HttpError::InvalidResponse("No trigger order history data in response".to_string())
+        })
+    }
+
+    /// Move positions between subaccounts
+    ///
+    /// Moves positions from a source subaccount to a target subaccount. This operation
+    /// transfers open positions between subaccounts, which is useful for rebalancing
+    /// or reorganizing trading activities.
+    ///
+    /// **Rate Limits**: 6 requests/minute, 100 move_position uses per week (168 hours)
+    ///
+    /// **Important**: In rare cases, the request may return an internal_server_error.
+    /// This does not necessarily mean the operation failed entirely. Part or all of
+    /// the position transfer might have still been processed successfully.
+    ///
+    /// # Arguments
+    ///
+    /// * `currency` - Currency symbol (e.g., "BTC", "ETH", "USDC")
+    /// * `source_uid` - Source subaccount ID
+    /// * `target_uid` - Target subaccount ID
+    /// * `trades` - List of position trades to move
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    /// use deribit_http::model::request::position::MovePositionTrade;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// let trades = vec![
+    ///     MovePositionTrade::with_price("BTC-PERPETUAL", 110.0, 35800.0),
+    /// ];
+    /// // let results = client.move_positions("BTC", 3, 23, &trades).await?;
+    /// ```
+    pub async fn move_positions(
+        &self,
+        currency: &str,
+        source_uid: i64,
+        target_uid: i64,
+        trades: &[MovePositionTrade],
+    ) -> Result<Vec<MovePositionResult>, HttpError> {
+        let mut url = format!(
+            "{}{}?currency={}&source_uid={}&target_uid={}",
+            self.base_url(),
+            MOVE_POSITIONS,
+            urlencoding::encode(currency),
+            source_uid,
+            target_uid
+        );
+
+        // Build trades array as JSON
+        let trades_json = serde_json::to_string(trades).map_err(|e| {
+            HttpError::InvalidResponse(format!("Failed to serialize trades: {}", e))
+        })?;
+        url.push_str(&format!("&trades={}", urlencoding::encode(&trades_json)));
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Move positions failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<Vec<MovePositionResult>> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response.result.ok_or_else(|| {
+            HttpError::InvalidResponse("No move positions data in response".to_string())
         })
     }
 

--- a/src/model/request/mod.rs
+++ b/src/model/request/mod.rs
@@ -10,9 +10,12 @@ pub mod api_request;
 pub mod mass_quote;
 /// Order request models and types
 pub mod order;
+/// Position request models
+pub mod position;
 /// Trade request models and structures
 pub mod trade;
 
 pub use api_request::*;
 pub use mass_quote::*;
 pub use order::*;
+pub use position::*;

--- a/src/model/request/position.rs
+++ b/src/model/request/position.rs
@@ -1,0 +1,143 @@
+/******************************************************************************
+   Author: Joaquín Béjar García
+   Email: jb@taunais.com
+   Date: 7/3/26
+******************************************************************************/
+//! Position request models
+
+use pretty_simple_display::{DebugPretty, DisplaySimple};
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+/// A single trade specification for moving positions
+///
+/// Represents a position trade to be moved between subaccounts.
+#[skip_serializing_none]
+#[derive(DebugPretty, DisplaySimple, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MovePositionTrade {
+    /// Instrument name (e.g., "BTC-PERPETUAL")
+    pub instrument_name: String,
+    /// Trade amount (USD for perpetual/inverse, base currency for options/linear)
+    pub amount: f64,
+    /// Price for trade (optional, defaults to average position price)
+    pub price: Option<f64>,
+}
+
+impl MovePositionTrade {
+    /// Create a new move position trade
+    pub fn new(instrument_name: impl Into<String>, amount: f64) -> Self {
+        Self {
+            instrument_name: instrument_name.into(),
+            amount,
+            price: None,
+        }
+    }
+
+    /// Create a new move position trade with a specific price
+    pub fn with_price(instrument_name: impl Into<String>, amount: f64, price: f64) -> Self {
+        Self {
+            instrument_name: instrument_name.into(),
+            amount,
+            price: Some(price),
+        }
+    }
+
+    /// Set the price for this trade
+    #[must_use]
+    pub fn price(mut self, price: f64) -> Self {
+        self.price = Some(price);
+        self
+    }
+}
+
+/// Request to move positions between subaccounts
+///
+/// Contains all parameters needed for the move_positions API call.
+#[derive(DebugPretty, DisplaySimple, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MovePositionsRequest {
+    /// Currency symbol (e.g., "BTC", "ETH", "USDC")
+    pub currency: String,
+    /// Source subaccount ID
+    pub source_uid: i64,
+    /// Target subaccount ID
+    pub target_uid: i64,
+    /// List of trades for position move
+    pub trades: Vec<MovePositionTrade>,
+}
+
+impl MovePositionsRequest {
+    /// Create a new move positions request
+    pub fn new(
+        currency: impl Into<String>,
+        source_uid: i64,
+        target_uid: i64,
+        trades: Vec<MovePositionTrade>,
+    ) -> Self {
+        Self {
+            currency: currency.into(),
+            source_uid,
+            target_uid,
+            trades,
+        }
+    }
+
+    /// Add a trade to the request
+    pub fn add_trade(&mut self, trade: MovePositionTrade) {
+        self.trades.push(trade);
+    }
+
+    /// Get the number of trades
+    pub fn trade_count(&self) -> usize {
+        self.trades.len()
+    }
+
+    /// Check if the request has any trades
+    pub fn has_trades(&self) -> bool {
+        !self.trades.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_move_position_trade_new() {
+        let trade = MovePositionTrade::new("BTC-PERPETUAL", 100.0);
+        assert_eq!(trade.instrument_name, "BTC-PERPETUAL");
+        assert_eq!(trade.amount, 100.0);
+        assert!(trade.price.is_none());
+    }
+
+    #[test]
+    fn test_move_position_trade_with_price() {
+        let trade = MovePositionTrade::with_price("BTC-PERPETUAL", 100.0, 35800.0);
+        assert_eq!(trade.instrument_name, "BTC-PERPETUAL");
+        assert_eq!(trade.amount, 100.0);
+        assert_eq!(trade.price, Some(35800.0));
+    }
+
+    #[test]
+    fn test_move_positions_request_new() {
+        let trades = vec![MovePositionTrade::new("BTC-PERPETUAL", 100.0)];
+        let request = MovePositionsRequest::new("BTC", 3, 23, trades);
+        assert_eq!(request.currency, "BTC");
+        assert_eq!(request.source_uid, 3);
+        assert_eq!(request.target_uid, 23);
+        assert_eq!(request.trade_count(), 1);
+    }
+
+    #[test]
+    fn test_move_positions_request_serialization() {
+        let trades = vec![
+            MovePositionTrade::with_price("BTC-PERPETUAL", 110.0, 35800.0),
+            MovePositionTrade::new("BTC-28JAN22-32500-C", 0.1),
+        ];
+        let request = MovePositionsRequest::new("BTC", 3, 23, trades);
+
+        let json = serde_json::to_string(&request).unwrap();
+        assert!(json.contains("BTC-PERPETUAL"));
+        assert!(json.contains("source_uid"));
+        assert!(json.contains("target_uid"));
+    }
+}

--- a/src/model/response/mod.rs
+++ b/src/model/response/mod.rs
@@ -17,6 +17,8 @@ pub mod mmp;
 pub mod order;
 /// Other response models and utilities
 pub mod other;
+/// Position response models
+pub mod position;
 /// Trade response models and types
 pub mod trade;
 /// Trigger order response models
@@ -31,6 +33,7 @@ pub use mass_quote::*;
 pub use mmp::*;
 pub use order::*;
 pub use other::*;
+pub use position::*;
 pub use trade::*;
 pub use trigger::*;
 pub use withdrawal::*;

--- a/src/model/response/position.rs
+++ b/src/model/response/position.rs
@@ -1,0 +1,109 @@
+/******************************************************************************
+   Author: Joaquín Béjar García
+   Email: jb@taunais.com
+   Date: 7/3/26
+******************************************************************************/
+//! Position response models
+
+use pretty_simple_display::{DebugPretty, DisplaySimple};
+use serde::{Deserialize, Serialize};
+
+/// Result of a single position move trade
+///
+/// Represents the outcome of moving a position between subaccounts.
+#[derive(DebugPretty, DisplaySimple, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MovePositionResult {
+    /// Instrument name (e.g., "BTC-PERPETUAL")
+    pub instrument_name: String,
+    /// Trade direction from source perspective ("buy" or "sell")
+    pub direction: String,
+    /// Price of the trade
+    pub price: f64,
+    /// Trade amount (USD for perpetual/inverse, base currency for options/linear)
+    pub amount: f64,
+    /// Source subaccount ID
+    pub source_uid: i64,
+    /// Target subaccount ID
+    pub target_uid: i64,
+}
+
+impl MovePositionResult {
+    /// Create a new move position result
+    pub fn new(
+        instrument_name: impl Into<String>,
+        direction: impl Into<String>,
+        price: f64,
+        amount: f64,
+        source_uid: i64,
+        target_uid: i64,
+    ) -> Self {
+        Self {
+            instrument_name: instrument_name.into(),
+            direction: direction.into(),
+            price,
+            amount,
+            source_uid,
+            target_uid,
+        }
+    }
+
+    /// Check if this is a buy trade
+    pub fn is_buy(&self) -> bool {
+        self.direction == "buy"
+    }
+
+    /// Check if this is a sell trade
+    pub fn is_sell(&self) -> bool {
+        self.direction == "sell"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_move_position_result_new() {
+        let result = MovePositionResult::new("BTC-PERPETUAL", "buy", 35800.0, 110.0, 3, 23);
+        assert_eq!(result.instrument_name, "BTC-PERPETUAL");
+        assert_eq!(result.direction, "buy");
+        assert_eq!(result.price, 35800.0);
+        assert_eq!(result.amount, 110.0);
+        assert_eq!(result.source_uid, 3);
+        assert_eq!(result.target_uid, 23);
+    }
+
+    #[test]
+    fn test_move_position_result_is_buy() {
+        let result = MovePositionResult::new("BTC-PERPETUAL", "buy", 35800.0, 110.0, 3, 23);
+        assert!(result.is_buy());
+        assert!(!result.is_sell());
+    }
+
+    #[test]
+    fn test_move_position_result_is_sell() {
+        let result = MovePositionResult::new("BTC-PERPETUAL", "sell", 35800.0, 110.0, 3, 23);
+        assert!(result.is_sell());
+        assert!(!result.is_buy());
+    }
+
+    #[test]
+    fn test_move_position_result_deserialization() {
+        let json = r#"{
+            "instrument_name": "BTC-PERPETUAL",
+            "direction": "buy",
+            "price": 35800.0,
+            "amount": 110.0,
+            "source_uid": 3,
+            "target_uid": 23
+        }"#;
+
+        let result: MovePositionResult = serde_json::from_str(json).unwrap();
+        assert_eq!(result.instrument_name, "BTC-PERPETUAL");
+        assert_eq!(result.direction, "buy");
+        assert_eq!(result.price, 35800.0);
+        assert_eq!(result.amount, 110.0);
+        assert_eq!(result.source_uid, 3);
+        assert_eq!(result.target_uid, 23);
+    }
+}

--- a/tests/integration/account_management/mod.rs
+++ b/tests/integration/account_management/mod.rs
@@ -4,6 +4,7 @@
 //! including account summary, positions, subaccounts, and transaction logs.
 
 pub mod account_summary;
+pub mod move_positions;
 pub mod positions;
 pub mod settlement_history;
 pub mod subaccounts;

--- a/tests/integration/account_management/move_positions.rs
+++ b/tests/integration/account_management/move_positions.rs
@@ -1,0 +1,64 @@
+//! Move positions integration tests
+//!
+//! Tests for private/move_positions endpoint.
+
+#[cfg(test)]
+mod move_positions_tests {
+    use deribit_http::DeribitHttpClient;
+    use deribit_http::model::request::position::MovePositionTrade;
+    use tokio::time::{Duration, Instant};
+    use tracing::info;
+
+    /// Test move_positions endpoint behavior
+    ///
+    /// Moves positions between subaccounts.
+    /// Note: This test requires valid subaccount IDs and open positions.
+    #[tokio::test]
+    #[serial_test::serial]
+    #[ignore = "Requires authentication and subaccounts with positions"]
+    async fn test_move_positions() -> Result<(), Box<dyn std::error::Error>> {
+        let client = DeribitHttpClient::new();
+
+        info!("Testing move_positions");
+        let start_time = Instant::now();
+
+        // Note: These are placeholder values - real test would need actual subaccount IDs
+        let trades = vec![MovePositionTrade::new("BTC-PERPETUAL", 10.0)];
+
+        let result = client.move_positions("BTC", 1, 2, &trades).await;
+        let elapsed = start_time.elapsed();
+
+        match &result {
+            Ok(results) => {
+                info!(
+                    "Move positions succeeded in {:?}: {} trades executed",
+                    elapsed,
+                    results.len()
+                );
+                for trade in results {
+                    info!(
+                        "  {} {} {} @ {} (source: {}, target: {})",
+                        trade.direction,
+                        trade.amount,
+                        trade.instrument_name,
+                        trade.price,
+                        trade.source_uid,
+                        trade.target_uid
+                    );
+                }
+            }
+            Err(e) => {
+                info!("Move positions failed in {:?}: {:?}", elapsed, e);
+            }
+        }
+
+        assert!(
+            elapsed < Duration::from_secs(30),
+            "Request took too long: {:?}",
+            elapsed
+        );
+
+        info!("test_move_positions completed");
+        Ok(())
+    }
+}

--- a/tests/unit/private_endpoints_tests.rs
+++ b/tests/unit/private_endpoints_tests.rs
@@ -1370,3 +1370,104 @@ async fn test_get_trigger_order_history_empty() {
     assert!(response.entries.is_empty());
     assert!(response.continuation.is_none());
 }
+
+// =========================================================================
+// Move Positions Tests (Issue #21)
+// =========================================================================
+
+#[tokio::test]
+async fn test_move_positions_success() {
+    use deribit_http::model::request::position::MovePositionTrade;
+
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": [
+            {
+                "target_uid": 23,
+                "source_uid": 3,
+                "price": 35800.0,
+                "instrument_name": "BTC-PERPETUAL",
+                "direction": "buy",
+                "amount": 110.0
+            },
+            {
+                "target_uid": 23,
+                "source_uid": 3,
+                "price": 0.1223,
+                "instrument_name": "BTC-28JAN22-32500-C",
+                "direction": "sell",
+                "amount": 0.1
+            }
+        ],
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(r"/api/v2/private/move_positions\?currency=BTC.*".to_string()),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let trades = vec![
+        MovePositionTrade::with_price("BTC-PERPETUAL", 110.0, 35800.0),
+        MovePositionTrade::new("BTC-28JAN22-32500-C", 0.1),
+    ];
+
+    let result = client.move_positions("BTC", 3, 23, &trades).await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let results = result.unwrap();
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0].instrument_name, "BTC-PERPETUAL");
+    assert_eq!(results[0].direction, "buy");
+    assert_eq!(results[0].amount, 110.0);
+    assert_eq!(results[1].instrument_name, "BTC-28JAN22-32500-C");
+    assert_eq!(results[1].direction, "sell");
+}
+
+#[tokio::test]
+async fn test_move_positions_empty() {
+    use deribit_http::model::request::position::MovePositionTrade;
+
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": [],
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(r"/api/v2/private/move_positions\?currency=ETH.*".to_string()),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let trades = vec![MovePositionTrade::new("ETH-PERPETUAL", 10.0)];
+
+    let result = client.move_positions("ETH", 1, 2, &trades).await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let results = result.unwrap();
+    assert!(results.is_empty());
+}


### PR DESCRIPTION
## Summary

Implement the `private/move_positions` endpoint for moving positions between subaccounts. This is useful for rebalancing or reorganizing trading activities.

## Endpoint

| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| `currency` | string | Yes | Currency symbol (BTC, ETH, USDC, etc.) |
| `source_uid` | i64 | Yes | Source subaccount ID |
| `target_uid` | i64 | Yes | Target subaccount ID |
| `trades` | array | Yes | List of position trades to move |

### Trade Object

| Field | Type | Required | Description |
|-------|------|----------|-------------|
| `instrument_name` | string | Yes | Instrument identifier |
| `amount` | f64 | Yes | Trade size |
| `price` | f64 | No | Price (defaults to avg position price) |

## Changes

- Add `MOVE_POSITIONS` constant in `src/constants.rs`
- Create `src/model/request/position.rs` with:
  - `MovePositionTrade` struct for specifying trades to move
  - `MovePositionsRequest` struct (convenience wrapper)
- Create `src/model/response/position.rs` with:
  - `MovePositionResult` struct for trade outcomes
- Add `pub mod position;` to both request and response `mod.rs`
- Implement `move_positions()` method in `src/endpoints/private.rs`
- Add 2 unit tests (success with multiple trades, empty response)
- Add 1 integration test (ignored, requires auth + subaccounts)
- Add 7 model unit tests

## API

```rust
pub async fn move_positions(
    &self,
    currency: &str,
    source_uid: i64,
    target_uid: i64,
    trades: &[MovePositionTrade],
) -> Result<Vec<MovePositionResult>, HttpError>
```

## Rate Limits (documented in method)

- **Sustained**: 6 requests/minute
- **Weekly**: 100 move_position uses per week (168 hours)

## Testing

- [x] Unit tests added (2 endpoint tests + 7 model tests)
- [x] Integration test added (ignored by default)
- [x] Manual testing (`cargo test --all-features`)
- [x] Doc-tests pass

## Checklist

- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] No `.unwrap()`, `.expect()`, or panics in library code
- [x] HTTP error handling implemented
- [x] New request/response models created with serialization tests
- [x] Rate limits documented in method docs

Closes #21
