### PR TITLE
M1 #22: Implement private/get_account_summaries endpoint

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -148,6 +148,8 @@ pub mod endpoints {
     // Private account endpoints
     /// Get account summary information
     pub const GET_ACCOUNT_SUMMARY: &str = "/private/get_account_summary";
+    /// Get account summaries for all currencies
+    pub const GET_ACCOUNT_SUMMARIES: &str = "/private/get_account_summaries";
     /// Get position
     pub const GET_POSITION: &str = "/private/get_position";
     /// Get current positions

--- a/src/endpoints/private.rs
+++ b/src/endpoints/private.rs
@@ -1126,6 +1126,78 @@ impl DeribitHttpClient {
         })
     }
 
+    /// Get account summaries for all currencies
+    ///
+    /// Retrieves a per-currency list of account summaries for the authenticated user.
+    /// Each summary includes balance, equity, available funds, and margin information
+    /// for each currency. Unlike `get_account_summary`, this returns data for all
+    /// currencies at once.
+    ///
+    /// # Arguments
+    ///
+    /// * `subaccount_id` - Retrieve summaries for a specific subaccount (optional)
+    /// * `extended` - Include additional account details (id, username, email, type) (optional)
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let summaries = client.get_account_summaries(None, Some(true)).await?;
+    /// ```
+    pub async fn get_account_summaries(
+        &self,
+        subaccount_id: Option<i64>,
+        extended: Option<bool>,
+    ) -> Result<AccountSummaryResponse, HttpError> {
+        let mut url = format!("{}{}", self.base_url(), GET_ACCOUNT_SUMMARIES);
+
+        let mut params = Vec::new();
+
+        if let Some(subaccount_id) = subaccount_id {
+            params.push(format!("subaccount_id={}", subaccount_id));
+        }
+
+        if let Some(extended) = extended {
+            params.push(format!("extended={}", extended));
+        }
+
+        if !params.is_empty() {
+            url.push('?');
+            url.push_str(&params.join("&"));
+        }
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get account summaries failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<AccountSummaryResponse> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response.result.ok_or_else(|| {
+            HttpError::InvalidResponse("No account summaries data in response".to_string())
+        })
+    }
+
     /// Get positions
     ///
     /// Retrieves user positions for the specified currency and kind.

--- a/tests/integration/account_management/account_summary.rs
+++ b/tests/integration/account_management/account_summary.rs
@@ -371,3 +371,55 @@ mod account_summary_tests {
         // - margin_balance >= balance
     }
 }
+
+#[cfg(test)]
+mod get_account_summaries_tests {
+    use deribit_http::DeribitHttpClient;
+    use tokio::time::{Duration, Instant};
+    use tracing::info;
+
+    /// Test get_account_summaries endpoint behavior
+    ///
+    /// Returns account summaries for all currencies at once.
+    #[tokio::test]
+    #[serial_test::serial]
+    #[ignore = "Requires authentication"]
+    async fn test_get_account_summaries() -> Result<(), Box<dyn std::error::Error>> {
+        let client = DeribitHttpClient::new();
+
+        info!("Testing get_account_summaries");
+        let start_time = Instant::now();
+
+        let result = client.get_account_summaries(None, Some(true)).await;
+        let elapsed = start_time.elapsed();
+
+        match &result {
+            Ok(response) => {
+                info!(
+                    "Get account summaries succeeded in {:?}: {} currency summaries found",
+                    elapsed,
+                    response.summaries.len()
+                );
+                info!(
+                    "Account ID: {}, Username: {}",
+                    response.id, response.username
+                );
+                for summary in &response.summaries {
+                    info!("  Currency: {}", summary.currency);
+                }
+            }
+            Err(e) => {
+                info!("Get account summaries failed in {:?}: {:?}", elapsed, e);
+            }
+        }
+
+        assert!(
+            elapsed < Duration::from_secs(30),
+            "Request took too long: {:?}",
+            elapsed
+        );
+
+        info!("test_get_account_summaries completed");
+        Ok(())
+    }
+}

--- a/tests/unit/private_endpoints_tests.rs
+++ b/tests/unit/private_endpoints_tests.rs
@@ -1471,3 +1471,140 @@ async fn test_move_positions_empty() {
     let results = result.unwrap();
     assert!(results.is_empty());
 }
+
+// =========================================================================
+// Get Account Summaries Tests (Issue #22)
+// =========================================================================
+
+#[tokio::test]
+async fn test_get_account_summaries_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": {
+            "id": 10,
+            "email": "user@example.com",
+            "system_name": "user",
+            "username": "user",
+            "block_rfq_self_match_prevention": true,
+            "creation_timestamp": 1687352432143i64,
+            "type": "main",
+            "referrer_id": null,
+            "login_enabled": true,
+            "security_keys_enabled": false,
+            "mmp_enabled": false,
+            "interuser_transfers_enabled": false,
+            "self_trading_reject_mode": "cancel_maker",
+            "self_trading_extended_to_subaccounts": false,
+            "summaries": [
+                {
+                    "currency": "BTC",
+                    "balance": 302.60065765,
+                    "equity": 302.61869214,
+                    "available_funds": 301.38059622,
+                    "available_withdrawal_funds": 301.35396172,
+                    "initial_margin": 1.24669592,
+                    "maintenance_margin": 0.8857841,
+                    "margin_balance": 302.62729214
+                },
+                {
+                    "currency": "ETH",
+                    "balance": 100.0,
+                    "equity": 100.0,
+                    "available_funds": 99.999598,
+                    "available_withdrawal_funds": 99.999597,
+                    "initial_margin": 0.000402,
+                    "maintenance_margin": 0.0,
+                    "margin_balance": 100.0
+                }
+            ]
+        },
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(r"/api/v2/private/get_account_summaries.*".to_string()),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.get_account_summaries(None, Some(true)).await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let response = result.unwrap();
+    assert_eq!(response.summaries.len(), 2);
+    assert_eq!(response.email, "user@example.com");
+    assert_eq!(response.username, "user");
+}
+
+#[tokio::test]
+async fn test_get_account_summaries_with_subaccount() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": {
+            "id": 20,
+            "email": "subaccount@example.com",
+            "system_name": "subuser",
+            "username": "subuser",
+            "block_rfq_self_match_prevention": false,
+            "creation_timestamp": 1687352432143i64,
+            "type": "subaccount",
+            "referrer_id": null,
+            "login_enabled": false,
+            "security_keys_enabled": false,
+            "mmp_enabled": false,
+            "interuser_transfers_enabled": false,
+            "self_trading_reject_mode": "cancel_maker",
+            "self_trading_extended_to_subaccounts": false,
+            "summaries": [
+                {
+                    "currency": "BTC",
+                    "balance": 10.0,
+                    "equity": 10.0,
+                    "available_funds": 10.0,
+                    "available_withdrawal_funds": 10.0,
+                    "initial_margin": 0.0,
+                    "maintenance_margin": 0.0,
+                    "margin_balance": 10.0
+                }
+            ]
+        },
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(
+                r"/api/v2/private/get_account_summaries\?subaccount_id=20.*".to_string(),
+            ),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.get_account_summaries(Some(20), None).await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let response = result.unwrap();
+    assert_eq!(response.summaries.len(), 1);
+    assert_eq!(response.account_type, "subaccount");
+}


### PR DESCRIPTION
## Summary

Implement the `private/get_account_summaries` endpoint for retrieving account summaries for all currencies at once (multi-currency version of `get_account_summary`).

## Endpoint

| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| `subaccount_id` | i64 | No | Retrieve summaries for specific subaccount |
| `extended` | bool | No | Include additional account details |

## Changes

- Add `GET_ACCOUNT_SUMMARIES` constant in `src/constants.rs`
- Implement `get_account_summaries()` method in `src/endpoints/private.rs`
- **Reuses existing `AccountSummaryResponse` model** — no new model needed
- Add 2 unit tests (success with multiple currencies, with subaccount_id)
- Add 1 integration test (ignored, requires authentication)

## API

```rust
pub async fn get_account_summaries(
    &self,
    subaccount_id: Option<i64>,
    extended: Option<bool>,
) -> Result<AccountSummaryResponse, HttpError>
```

## Key Insight

The existing `AccountSummaryResponse` already contains `summaries: Vec<AccountResult>` for per-currency data, so **no new model was required** for this endpoint.

## Testing

- [x] Unit tests added (2 tests)
- [x] Integration test added (ignored by default)
- [x] Manual testing (`cargo test --all-features`)
- [x] Doc-tests pass

## Checklist

- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] No `.unwrap()`, `.expect()`, or panics in library code
- [x] HTTP error handling implemented
- [x] Reuses existing model (AccountSummaryResponse)

Closes #22
