### PR TITLE
M1 #24: Implement API key management endpoints

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -200,6 +200,26 @@ pub mod endpoints {
         "/private/get_user_trades_by_instrument_and_time";
     /// Get user trades by order
     pub const GET_USER_TRADES_BY_ORDER: &str = "/private/get_user_trades_by_order";
+
+    // API Key Management endpoints
+    /// Create a new API key
+    pub const CREATE_API_KEY: &str = "/private/create_api_key";
+    /// Edit an existing API key
+    pub const EDIT_API_KEY: &str = "/private/edit_api_key";
+    /// Disable an API key
+    pub const DISABLE_API_KEY: &str = "/private/disable_api_key";
+    /// Enable an API key
+    pub const ENABLE_API_KEY: &str = "/private/enable_api_key";
+    /// List all API keys
+    pub const LIST_API_KEYS: &str = "/private/list_api_keys";
+    /// Remove an API key
+    pub const REMOVE_API_KEY: &str = "/private/remove_api_key";
+    /// Reset an API key secret
+    pub const RESET_API_KEY: &str = "/private/reset_api_key";
+    /// Change API key name
+    pub const CHANGE_API_KEY_NAME: &str = "/private/change_api_key_name";
+    /// Change API key scope
+    pub const CHANGE_SCOPE_IN_API_KEY: &str = "/private/change_scope_in_api_key";
 }
 
 /// HTTP headers

--- a/src/endpoints/private.rs
+++ b/src/endpoints/private.rs
@@ -4,6 +4,7 @@ use crate::DeribitHttpClient;
 use crate::constants::endpoints::*;
 use crate::error::HttpError;
 use crate::model::account::Subaccount;
+use crate::model::api_key::{ApiKeyInfo, CreateApiKeyRequest, EditApiKeyRequest};
 use crate::model::position::Position;
 use crate::model::request::mass_quote::MassQuoteRequest;
 use crate::model::request::order::OrderRequest;
@@ -3605,5 +3606,544 @@ impl DeribitHttpClient {
         api_response.result.ok_or_else(|| {
             HttpError::InvalidResponse("No user trades data in response".to_string())
         })
+    }
+
+    // ==================== API Key Management ====================
+
+    /// Create a new API key
+    ///
+    /// Creates a new API key with the specified scope and optional settings.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The create API key request parameters
+    ///
+    /// # Returns
+    ///
+    /// Returns the newly created API key information including client_id and client_secret.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or authentication is invalid.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use deribit_http::{DeribitHttpClient, model::CreateApiKeyRequest};
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = DeribitHttpClient::new();
+    /// let request = CreateApiKeyRequest {
+    ///     max_scope: "account:read trade:read_write".to_string(),
+    ///     name: Some("my_trading_key".to_string()),
+    ///     ..Default::default()
+    /// };
+    /// let api_key = client.create_api_key(request).await?;
+    /// println!("Created API key: {}", api_key.client_id);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create_api_key(
+        &self,
+        request: CreateApiKeyRequest,
+    ) -> Result<ApiKeyInfo, HttpError> {
+        let mut query_params = vec![("max_scope".to_string(), request.max_scope)];
+
+        if let Some(name) = request.name {
+            query_params.push(("name".to_string(), name));
+        }
+
+        if let Some(public_key) = request.public_key {
+            query_params.push(("public_key".to_string(), public_key));
+        }
+
+        if let Some(enabled_features) = request.enabled_features {
+            for feature in enabled_features {
+                query_params.push(("enabled_features".to_string(), feature));
+            }
+        }
+
+        let query_string = query_params
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
+            .collect::<Vec<_>>()
+            .join("&");
+
+        let url = format!("{}{}?{}", self.base_url(), CREATE_API_KEY, query_string);
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Create API key failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<ApiKeyInfo> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No API key data in response".to_string()))
+    }
+
+    /// Edit an existing API key
+    ///
+    /// Modifies an existing API key's scope, name, or other settings.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The edit API key request parameters
+    ///
+    /// # Returns
+    ///
+    /// Returns the updated API key information.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or the API key is not found.
+    pub async fn edit_api_key(&self, request: EditApiKeyRequest) -> Result<ApiKeyInfo, HttpError> {
+        let mut query_params = vec![
+            ("id".to_string(), request.id.to_string()),
+            ("max_scope".to_string(), request.max_scope),
+        ];
+
+        if let Some(name) = request.name {
+            query_params.push(("name".to_string(), name));
+        }
+
+        if let Some(enabled) = request.enabled {
+            query_params.push(("enabled".to_string(), enabled.to_string()));
+        }
+
+        if let Some(enabled_features) = request.enabled_features {
+            for feature in enabled_features {
+                query_params.push(("enabled_features".to_string(), feature));
+            }
+        }
+
+        if let Some(ip_whitelist) = request.ip_whitelist {
+            for ip in ip_whitelist {
+                query_params.push(("ip_whitelist".to_string(), ip));
+            }
+        }
+
+        let query_string = query_params
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
+            .collect::<Vec<_>>()
+            .join("&");
+
+        let url = format!("{}{}?{}", self.base_url(), EDIT_API_KEY, query_string);
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Edit API key failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<ApiKeyInfo> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No API key data in response".to_string()))
+    }
+
+    /// Disable an API key
+    ///
+    /// Disables the API key with the specified ID. The key cannot be used
+    /// for authentication until it is re-enabled.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The ID of the API key to disable
+    ///
+    /// # Returns
+    ///
+    /// Returns the updated API key information with `enabled` set to `false`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or the API key is not found.
+    pub async fn disable_api_key(&self, id: u64) -> Result<ApiKeyInfo, HttpError> {
+        let url = format!("{}{}?id={}", self.base_url(), DISABLE_API_KEY, id);
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Disable API key failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<ApiKeyInfo> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No API key data in response".to_string()))
+    }
+
+    /// Enable an API key
+    ///
+    /// Enables a previously disabled API key with the specified ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The ID of the API key to enable
+    ///
+    /// # Returns
+    ///
+    /// Returns the updated API key information with `enabled` set to `true`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or the API key is not found.
+    pub async fn enable_api_key(&self, id: u64) -> Result<ApiKeyInfo, HttpError> {
+        let url = format!("{}{}?id={}", self.base_url(), ENABLE_API_KEY, id);
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Enable API key failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<ApiKeyInfo> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No API key data in response".to_string()))
+    }
+
+    /// List all API keys
+    ///
+    /// Retrieves a list of all API keys associated with the account.
+    ///
+    /// # Returns
+    ///
+    /// Returns a vector of API key information.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or authentication is invalid.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = DeribitHttpClient::new();
+    /// let api_keys = client.list_api_keys().await?;
+    /// for key in api_keys {
+    ///     println!("Key ID: {}, Name: {}, Enabled: {}", key.id, key.name, key.enabled);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list_api_keys(&self) -> Result<Vec<ApiKeyInfo>, HttpError> {
+        let url = format!("{}{}", self.base_url(), LIST_API_KEYS);
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "List API keys failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<Vec<ApiKeyInfo>> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No API keys data in response".to_string()))
+    }
+
+    /// Remove an API key
+    ///
+    /// Permanently removes the API key with the specified ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The ID of the API key to remove
+    ///
+    /// # Returns
+    ///
+    /// Returns `"ok"` on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or the API key is not found.
+    pub async fn remove_api_key(&self, id: u64) -> Result<String, HttpError> {
+        let url = format!("{}{}?id={}", self.base_url(), REMOVE_API_KEY, id);
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Remove API key failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<String> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No result in response".to_string()))
+    }
+
+    /// Reset an API key secret
+    ///
+    /// Generates a new client_secret for the API key with the specified ID.
+    /// The old secret will no longer be valid.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The ID of the API key to reset
+    ///
+    /// # Returns
+    ///
+    /// Returns the updated API key information with the new client_secret.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or the API key is not found.
+    pub async fn reset_api_key(&self, id: u64) -> Result<ApiKeyInfo, HttpError> {
+        let url = format!("{}{}?id={}", self.base_url(), RESET_API_KEY, id);
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Reset API key failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<ApiKeyInfo> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No API key data in response".to_string()))
+    }
+
+    /// Change API key name
+    ///
+    /// Changes the name of the API key with the specified ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The ID of the API key
+    /// * `name` - The new name (only letters, numbers and underscores; max 16 characters)
+    ///
+    /// # Returns
+    ///
+    /// Returns the updated API key information.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or the API key is not found.
+    pub async fn change_api_key_name(&self, id: u64, name: &str) -> Result<ApiKeyInfo, HttpError> {
+        let url = format!(
+            "{}{}?id={}&name={}",
+            self.base_url(),
+            CHANGE_API_KEY_NAME,
+            id,
+            urlencoding::encode(name)
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Change API key name failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<ApiKeyInfo> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No API key data in response".to_string()))
+    }
+
+    /// Change API key scope
+    ///
+    /// Changes the maximum scope of the API key with the specified ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The ID of the API key
+    /// * `max_scope` - The new maximum scope (e.g., "account:read trade:read_write")
+    ///
+    /// # Returns
+    ///
+    /// Returns the updated API key information.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or the API key is not found.
+    pub async fn change_scope_in_api_key(
+        &self,
+        id: u64,
+        max_scope: &str,
+    ) -> Result<ApiKeyInfo, HttpError> {
+        let url = format!(
+            "{}{}?id={}&max_scope={}",
+            self.base_url(),
+            CHANGE_SCOPE_IN_API_KEY,
+            id,
+            urlencoding::encode(max_scope)
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Change API key scope failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<ApiKeyInfo> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No API key data in response".to_string()))
     }
 }

--- a/src/model/api_key.rs
+++ b/src/model/api_key.rs
@@ -1,0 +1,202 @@
+//! API key management models and types
+
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+/// API key information returned by API key management endpoints.
+///
+/// Contains all details about an API key including credentials,
+/// permissions, and configuration.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiKeyInfo {
+    /// Unique identifier for the API key
+    pub id: u64,
+    /// Client identifier used for authentication
+    pub client_id: String,
+    /// Client secret or MD5 fingerprint of public key used for authentication
+    pub client_secret: String,
+    /// API key name that can be displayed in transaction log
+    pub name: String,
+    /// Describes maximal access for tokens generated with this key.
+    ///
+    /// Possible values include combinations of:
+    /// - `trade:[read, read_write, none]`
+    /// - `wallet:[read, read_write, none]`
+    /// - `account:[read, read_write, none]`
+    /// - `block_trade:[read, read_write, none]`
+    /// - `block_rfq:[read, read_write, none]`
+    pub max_scope: String,
+    /// Whether the API key is enabled and can be used for authentication
+    pub enabled: bool,
+    /// Whether this API key is the default (deprecated, will be removed)
+    pub default: bool,
+    /// Timestamp when the key was created or last modified, in milliseconds since Unix epoch
+    pub timestamp: u64,
+    /// List of enabled advanced on-key features.
+    ///
+    /// Available options:
+    /// - `restricted_block_trades`: Limit block_trade read scope to trades made with this key
+    /// - `block_trade_approval`: Block trades require additional user approval
+    #[serde(default)]
+    pub enabled_features: Vec<String>,
+    /// List of IP addresses whitelisted for this key
+    #[serde(default)]
+    pub ip_whitelist: Option<Vec<String>>,
+    /// PEM encoded public key (Ed25519/RSA) used for asymmetric signatures
+    pub public_key: Option<String>,
+}
+
+/// Request parameters for creating a new API key.
+///
+/// # Example
+///
+/// ```rust
+/// use deribit_http::model::CreateApiKeyRequest;
+///
+/// let request = CreateApiKeyRequest {
+///     max_scope: "account:read trade:read_write".to_string(),
+///     name: Some("my_trading_key".to_string()),
+///     ..Default::default()
+/// };
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct CreateApiKeyRequest {
+    /// Describes maximal access for tokens generated with this key.
+    ///
+    /// Required. Possible values include combinations of:
+    /// - `trade:[read, read_write, none]`
+    /// - `wallet:[read, read_write, none]`
+    /// - `account:[read, read_write, none]`
+    /// - `block_trade:[read, read_write, none]`
+    pub max_scope: String,
+    /// Name of key (only letters, numbers and underscores; max 16 characters)
+    pub name: Option<String>,
+    /// ED25519 or RSA PEM encoded public key for asymmetric API key authentication
+    pub public_key: Option<String>,
+    /// List of enabled advanced on-key features.
+    ///
+    /// Available options:
+    /// - `restricted_block_trades`
+    /// - `block_trade_approval`
+    pub enabled_features: Option<Vec<String>>,
+}
+
+/// Request parameters for editing an existing API key.
+///
+/// At least one optional parameter must be provided along with the required fields.
+///
+/// # Example
+///
+/// ```rust
+/// use deribit_http::model::EditApiKeyRequest;
+///
+/// let request = EditApiKeyRequest {
+///     id: 123,
+///     max_scope: "account:read_write trade:read_write".to_string(),
+///     name: Some("updated_key_name".to_string()),
+///     ..Default::default()
+/// };
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct EditApiKeyRequest {
+    /// ID of the API key to edit
+    pub id: u64,
+    /// Describes maximal access for tokens generated with this key.
+    ///
+    /// Required. Possible values include combinations of:
+    /// - `trade:[read, read_write, none]`
+    /// - `wallet:[read, read_write, none]`
+    /// - `account:[read, read_write, none]`
+    /// - `block_trade:[read, read_write, none]`
+    pub max_scope: String,
+    /// Name of key (only letters, numbers and underscores; max 16 characters)
+    pub name: Option<String>,
+    /// Enable or disable the API key
+    pub enabled: Option<bool>,
+    /// List of enabled advanced on-key features
+    pub enabled_features: Option<Vec<String>>,
+    /// List of IP addresses to whitelist for this key
+    pub ip_whitelist: Option<Vec<String>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_api_key_info_deserialization() {
+        let json = r#"{
+            "timestamp": 1560238048714,
+            "max_scope": "account:read block_trade:read_write trade:read wallet:none",
+            "id": 5,
+            "enabled": true,
+            "enabled_features": [],
+            "default": false,
+            "public_key": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAM7FWhKquNqLmTOV4hfYT5r3AjrYiORTT6Tn5HIfFNV8=\n-----END PUBLIC KEY-----",
+            "client_secret": "9c:6d:c9:02:fd:9f:75:6e:14:bb:71:c5:74:95:86:c8",
+            "client_id": "wcVoQGam",
+            "name": ""
+        }"#;
+
+        let info: ApiKeyInfo = serde_json::from_str(json).expect("Failed to deserialize");
+        assert_eq!(info.id, 5);
+        assert_eq!(info.client_id, "wcVoQGam");
+        assert!(info.enabled);
+        assert!(!info.default);
+        assert!(info.public_key.is_some());
+    }
+
+    #[test]
+    fn test_api_key_info_list_deserialization() {
+        let json = r#"[
+            {
+                "timestamp": 1560236001108,
+                "max_scope": "account:read block_trade:read trade:read_write wallet:read",
+                "id": 1,
+                "enabled": false,
+                "default": false,
+                "client_secret": "SjM57m1T2CfXZ4vZ76X1APjqRlJdtzHI8IwVXoQnfoM",
+                "client_id": "TiA4AyLPq3",
+                "name": "",
+                "enabled_features": []
+            },
+            {
+                "timestamp": 1560236287708,
+                "max_scope": "account:read_write block_trade:read_write trade:read_write wallet:read_write",
+                "id": 2,
+                "enabled": true,
+                "default": true,
+                "client_secret": "mwNOvbUVyQczytQ5IVM8CbzmgqNJ81WvLKfu6MXcJPs",
+                "client_id": "aD-KFx-H",
+                "name": "",
+                "enabled_features": []
+            }
+        ]"#;
+
+        let keys: Vec<ApiKeyInfo> = serde_json::from_str(json).expect("Failed to deserialize");
+        assert_eq!(keys.len(), 2);
+        assert_eq!(keys[0].id, 1);
+        assert!(!keys[0].enabled);
+        assert_eq!(keys[1].id, 2);
+        assert!(keys[1].enabled);
+    }
+
+    #[test]
+    fn test_create_api_key_request_default() {
+        let request = CreateApiKeyRequest::default();
+        assert!(request.max_scope.is_empty());
+        assert!(request.name.is_none());
+        assert!(request.public_key.is_none());
+        assert!(request.enabled_features.is_none());
+    }
+
+    #[test]
+    fn test_edit_api_key_request_default() {
+        let request = EditApiKeyRequest::default();
+        assert_eq!(request.id, 0);
+        assert!(request.max_scope.is_empty());
+        assert!(request.name.is_none());
+        assert!(request.enabled.is_none());
+    }
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -3,6 +3,8 @@
 // HTTP-specific models
 /// Account-related models and structures
 pub mod account;
+/// API key management models
+pub mod api_key;
 /// Order book models
 pub mod book;
 /// Currency and expiration models
@@ -51,6 +53,7 @@ pub mod types;
 pub mod withdrawal;
 
 pub use account::*;
+pub use api_key::*;
 pub use book::*;
 pub use currency::*;
 pub use deposit::*;

--- a/tests/unit/api_key_tests.rs
+++ b/tests/unit/api_key_tests.rs
@@ -1,0 +1,222 @@
+//! Unit tests for API key management models
+
+use deribit_http::model::{ApiKeyInfo, CreateApiKeyRequest, EditApiKeyRequest};
+
+#[test]
+fn test_api_key_info_deserialization_full() {
+    let json = r#"{
+        "timestamp": 1560238048714,
+        "max_scope": "account:read block_trade:read_write trade:read wallet:none",
+        "id": 5,
+        "enabled": true,
+        "enabled_features": ["restricted_block_trades"],
+        "default": false,
+        "public_key": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAM7FWhKquNqLmTOV4hfYT5r3AjrYiORTT6Tn5HIfFNV8=\n-----END PUBLIC KEY-----",
+        "client_secret": "9c:6d:c9:02:fd:9f:75:6e:14:bb:71:c5:74:95:86:c8",
+        "client_id": "wcVoQGam",
+        "name": "my_key",
+        "ip_whitelist": ["192.168.1.1", "10.0.0.1"]
+    }"#;
+
+    let info: ApiKeyInfo = serde_json::from_str(json).expect("Failed to deserialize");
+    assert_eq!(info.id, 5);
+    assert_eq!(info.client_id, "wcVoQGam");
+    assert_eq!(
+        info.client_secret,
+        "9c:6d:c9:02:fd:9f:75:6e:14:bb:71:c5:74:95:86:c8"
+    );
+    assert_eq!(info.name, "my_key");
+    assert_eq!(
+        info.max_scope,
+        "account:read block_trade:read_write trade:read wallet:none"
+    );
+    assert!(info.enabled);
+    assert!(!info.default);
+    assert_eq!(info.timestamp, 1560238048714);
+    assert_eq!(info.enabled_features.len(), 1);
+    assert_eq!(info.enabled_features[0], "restricted_block_trades");
+    assert!(info.public_key.is_some());
+    assert!(info.ip_whitelist.is_some());
+    assert_eq!(info.ip_whitelist.as_ref().map(|v| v.len()), Some(2));
+}
+
+#[test]
+fn test_api_key_info_deserialization_minimal() {
+    let json = r#"{
+        "timestamp": 1560242676023,
+        "max_scope": "account:read_write block_trade:read trade:read_write wallet:read_write",
+        "id": 3,
+        "enabled": false,
+        "default": false,
+        "client_secret": "B6RsF9rrLY5ezEGBQkyLlV-UC7whyPJ34BMA-kKYpes",
+        "client_id": "1sXMQBhM",
+        "name": ""
+    }"#;
+
+    let info: ApiKeyInfo = serde_json::from_str(json).expect("Failed to deserialize");
+    assert_eq!(info.id, 3);
+    assert_eq!(info.client_id, "1sXMQBhM");
+    assert!(!info.enabled);
+    assert!(info.name.is_empty());
+    assert!(info.enabled_features.is_empty());
+    assert!(info.ip_whitelist.is_none());
+    assert!(info.public_key.is_none());
+}
+
+#[test]
+fn test_api_key_info_list_deserialization() {
+    let json = r#"[
+        {
+            "timestamp": 1560236001108,
+            "max_scope": "account:read block_trade:read trade:read_write wallet:read",
+            "id": 1,
+            "enabled": false,
+            "default": false,
+            "client_secret": "SjM57m1T2CfXZ4vZ76X1APjqRlJdtzHI8IwVXoQnfoM",
+            "client_id": "TiA4AyLPq3",
+            "name": "",
+            "enabled_features": []
+        },
+        {
+            "timestamp": 1560236287708,
+            "max_scope": "account:read_write block_trade:read_write trade:read_write wallet:read_write",
+            "id": 2,
+            "enabled": true,
+            "default": true,
+            "client_secret": "mwNOvbUVyQczytQ5IVM8CbzmgqNJ81WvLKfu6MXcJPs",
+            "client_id": "aD-KFx-H",
+            "name": "",
+            "enabled_features": []
+        }
+    ]"#;
+
+    let keys: Vec<ApiKeyInfo> = serde_json::from_str(json).expect("Failed to deserialize");
+    assert_eq!(keys.len(), 2);
+
+    assert_eq!(keys[0].id, 1);
+    assert_eq!(keys[0].client_id, "TiA4AyLPq3");
+    assert!(!keys[0].enabled);
+    assert!(!keys[0].default);
+
+    assert_eq!(keys[1].id, 2);
+    assert_eq!(keys[1].client_id, "aD-KFx-H");
+    assert!(keys[1].enabled);
+    assert!(keys[1].default);
+}
+
+#[test]
+fn test_api_key_info_serialization() {
+    let info = ApiKeyInfo {
+        id: 1,
+        client_id: "test_client".to_string(),
+        client_secret: "test_secret".to_string(),
+        name: "test_key".to_string(),
+        max_scope: "account:read".to_string(),
+        enabled: true,
+        default: false,
+        timestamp: 1234567890,
+        enabled_features: vec!["block_trade_approval".to_string()],
+        ip_whitelist: Some(vec!["127.0.0.1".to_string()]),
+        public_key: None,
+    };
+
+    let json = serde_json::to_string(&info).expect("Failed to serialize");
+    assert!(json.contains("\"id\":1"));
+    assert!(json.contains("\"client_id\":\"test_client\""));
+    assert!(json.contains("\"enabled\":true"));
+    assert!(json.contains("\"block_trade_approval\""));
+}
+
+#[test]
+fn test_create_api_key_request_default() {
+    let request = CreateApiKeyRequest::default();
+    assert!(request.max_scope.is_empty());
+    assert!(request.name.is_none());
+    assert!(request.public_key.is_none());
+    assert!(request.enabled_features.is_none());
+}
+
+#[test]
+fn test_create_api_key_request_with_values() {
+    let request = CreateApiKeyRequest {
+        max_scope: "account:read trade:read_write".to_string(),
+        name: Some("my_trading_key".to_string()),
+        public_key: Some("-----BEGIN PUBLIC KEY-----\ntest\n-----END PUBLIC KEY-----".to_string()),
+        enabled_features: Some(vec!["restricted_block_trades".to_string()]),
+    };
+
+    assert_eq!(request.max_scope, "account:read trade:read_write");
+    assert_eq!(request.name, Some("my_trading_key".to_string()));
+    assert!(request.public_key.is_some());
+    assert!(request.enabled_features.is_some());
+    assert_eq!(request.enabled_features.as_ref().map(|v| v.len()), Some(1));
+}
+
+#[test]
+fn test_edit_api_key_request_default() {
+    let request = EditApiKeyRequest::default();
+    assert_eq!(request.id, 0);
+    assert!(request.max_scope.is_empty());
+    assert!(request.name.is_none());
+    assert!(request.enabled.is_none());
+    assert!(request.enabled_features.is_none());
+    assert!(request.ip_whitelist.is_none());
+}
+
+#[test]
+fn test_edit_api_key_request_with_values() {
+    let request = EditApiKeyRequest {
+        id: 123,
+        max_scope: "account:read_write wallet:read".to_string(),
+        name: Some("updated_name".to_string()),
+        enabled: Some(false),
+        enabled_features: Some(vec!["block_trade_approval".to_string()]),
+        ip_whitelist: Some(vec!["10.0.0.1".to_string(), "192.168.1.1".to_string()]),
+    };
+
+    assert_eq!(request.id, 123);
+    assert_eq!(request.max_scope, "account:read_write wallet:read");
+    assert_eq!(request.name, Some("updated_name".to_string()));
+    assert_eq!(request.enabled, Some(false));
+    assert!(request.enabled_features.is_some());
+    assert!(request.ip_whitelist.is_some());
+    assert_eq!(request.ip_whitelist.as_ref().map(|v| v.len()), Some(2));
+}
+
+#[test]
+fn test_api_key_info_with_empty_enabled_features() {
+    let json = r#"{
+        "timestamp": 1560238048714,
+        "max_scope": "account:read",
+        "id": 1,
+        "enabled": true,
+        "enabled_features": [],
+        "default": false,
+        "client_secret": "secret",
+        "client_id": "client",
+        "name": "key"
+    }"#;
+
+    let info: ApiKeyInfo = serde_json::from_str(json).expect("Failed to deserialize");
+    assert!(info.enabled_features.is_empty());
+}
+
+#[test]
+fn test_api_key_info_without_optional_fields() {
+    // Test deserialization when optional fields are missing entirely
+    let json = r#"{
+        "timestamp": 1560238048714,
+        "max_scope": "account:read",
+        "id": 1,
+        "enabled": true,
+        "default": false,
+        "client_secret": "secret",
+        "client_id": "client",
+        "name": "key"
+    }"#;
+
+    let info: ApiKeyInfo = serde_json::from_str(json).expect("Failed to deserialize");
+    assert!(info.enabled_features.is_empty());
+    assert!(info.ip_whitelist.is_none());
+    assert!(info.public_key.is_none());
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -4,6 +4,7 @@
    Date: 16/8/25
 ******************************************************************************/
 
+pub mod api_key_tests;
 pub mod book_tests;
 pub mod builder_tests;
 pub mod client_tests;


### PR DESCRIPTION
## Summary

Implements all 9 API key management endpoints for the Deribit HTTP client, enabling users to create, edit, enable/disable, list, remove, and reset API keys programmatically.

## Changes

- Add 9 endpoint constants to `src/constants.rs` for API key management
- Create `src/model/api_key.rs` with `ApiKeyInfo`, `CreateApiKeyRequest`, and `EditApiKeyRequest` types
- Implement 9 client methods on `DeribitHttpClient` in `src/endpoints/private.rs`:
  - `create_api_key`, `edit_api_key`, `disable_api_key`, `enable_api_key`
  - `list_api_keys`, `remove_api_key`, `reset_api_key`
  - `change_api_key_name`, `change_scope_in_api_key`
- Add unit tests for API key model serialization/deserialization

## Technical Decisions

- Used `serde(default)` for `enabled_features` to handle missing field in API responses
- Request structs use `Default` trait for builder-like construction pattern
- All methods follow existing endpoint patterns with consistent error handling

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] Benchmark tests added/updated (if applicable)
- [x] Manual testing performed (`cargo test --all-features`)

## Checklist

- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] No `.unwrap()`, `.expect()`, or panics in library code
- [x] HTTP error handling implemented
- [x] Minimal dependencies — no unnecessary crates added

Closes #24
