### PR TITLE
M1 #25: Implement subaccount management endpoints

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -158,6 +158,19 @@ pub mod endpoints {
     pub const GET_SUBACCOUNTS: &str = "/private/get_subaccounts";
     /// Get subaccounts details with positions
     pub const GET_SUBACCOUNTS_DETAILS: &str = "/private/get_subaccounts_details";
+    /// Create a new subaccount
+    pub const CREATE_SUBACCOUNT: &str = "/private/create_subaccount";
+    /// Remove an empty subaccount
+    pub const REMOVE_SUBACCOUNT: &str = "/private/remove_subaccount";
+    /// Change the name of a subaccount
+    pub const CHANGE_SUBACCOUNT_NAME: &str = "/private/change_subaccount_name";
+    /// Enable or disable login for a subaccount
+    pub const TOGGLE_SUBACCOUNT_LOGIN: &str = "/private/toggle_subaccount_login";
+    /// Set email address for a subaccount
+    pub const SET_EMAIL_FOR_SUBACCOUNT: &str = "/private/set_email_for_subaccount";
+    /// Enable or disable notifications for a subaccount
+    pub const TOGGLE_NOTIFICATIONS_FROM_SUBACCOUNT: &str =
+        "/private/toggle_notifications_from_subaccount";
     /// Get transaction log
     pub const GET_TRANSACTION_LOG: &str = "/private/get_transaction_log";
     /// Get deposits

--- a/src/endpoints/private.rs
+++ b/src/endpoints/private.rs
@@ -175,6 +175,397 @@ impl DeribitHttpClient {
         })
     }
 
+    /// Create a new subaccount
+    ///
+    /// Creates a new subaccount under the main account.
+    ///
+    /// # Returns
+    ///
+    /// Returns the newly created `Subaccount` with its details.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or if the user is not a main account.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let subaccount = client.create_subaccount().await?;
+    /// // tracing::info!("Created subaccount with ID: {}", subaccount.id);
+    /// ```
+    pub async fn create_subaccount(&self) -> Result<Subaccount, HttpError> {
+        let url = format!("{}{}", self.base_url(), CREATE_SUBACCOUNT);
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Create subaccount failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<Subaccount> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No subaccount data in response".to_string()))
+    }
+
+    /// Remove an empty subaccount
+    ///
+    /// Removes a subaccount that has no open positions or pending orders.
+    ///
+    /// # Arguments
+    ///
+    /// * `subaccount_id` - The ID of the subaccount to remove
+    ///
+    /// # Returns
+    ///
+    /// Returns `"ok"` on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or if the subaccount is not empty.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let result = client.remove_subaccount(123).await?;
+    /// // assert_eq!(result, "ok");
+    /// ```
+    pub async fn remove_subaccount(&self, subaccount_id: u64) -> Result<String, HttpError> {
+        let url = format!(
+            "{}{}?subaccount_id={}",
+            self.base_url(),
+            REMOVE_SUBACCOUNT,
+            subaccount_id
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Remove subaccount failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<String> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No result in response".to_string()))
+    }
+
+    /// Change the name of a subaccount
+    ///
+    /// Updates the username for a subaccount.
+    ///
+    /// # Arguments
+    ///
+    /// * `sid` - The subaccount ID
+    /// * `name` - The new username for the subaccount
+    ///
+    /// # Returns
+    ///
+    /// Returns `"ok"` on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let result = client.change_subaccount_name(123, "new_name").await?;
+    /// // assert_eq!(result, "ok");
+    /// ```
+    pub async fn change_subaccount_name(&self, sid: u64, name: &str) -> Result<String, HttpError> {
+        let url = format!(
+            "{}{}?sid={}&name={}",
+            self.base_url(),
+            CHANGE_SUBACCOUNT_NAME,
+            sid,
+            urlencoding::encode(name)
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Change subaccount name failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<String> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No result in response".to_string()))
+    }
+
+    /// Enable or disable login for a subaccount
+    ///
+    /// Toggles whether a subaccount can log in. If login is disabled and a session
+    /// for the subaccount exists, that session will be terminated.
+    ///
+    /// # Arguments
+    ///
+    /// * `sid` - The subaccount ID
+    /// * `state` - Either `"enable"` or `"disable"`
+    ///
+    /// # Returns
+    ///
+    /// Returns `"ok"` on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let result = client.toggle_subaccount_login(123, "enable").await?;
+    /// // assert_eq!(result, "ok");
+    /// ```
+    pub async fn toggle_subaccount_login(
+        &self,
+        sid: u64,
+        state: &str,
+    ) -> Result<String, HttpError> {
+        let url = format!(
+            "{}{}?sid={}&state={}",
+            self.base_url(),
+            TOGGLE_SUBACCOUNT_LOGIN,
+            sid,
+            urlencoding::encode(state)
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Toggle subaccount login failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<String> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No result in response".to_string()))
+    }
+
+    /// Set email address for a subaccount
+    ///
+    /// Assigns an email address to a subaccount. The user will receive an email
+    /// with a confirmation link.
+    ///
+    /// # Arguments
+    ///
+    /// * `sid` - The subaccount ID
+    /// * `email` - The email address to assign
+    ///
+    /// # Returns
+    ///
+    /// Returns `"ok"` on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let result = client.set_email_for_subaccount(123, "user@example.com").await?;
+    /// // assert_eq!(result, "ok");
+    /// ```
+    pub async fn set_email_for_subaccount(
+        &self,
+        sid: u64,
+        email: &str,
+    ) -> Result<String, HttpError> {
+        let url = format!(
+            "{}{}?sid={}&email={}",
+            self.base_url(),
+            SET_EMAIL_FOR_SUBACCOUNT,
+            sid,
+            urlencoding::encode(email)
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Set email for subaccount failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<String> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No result in response".to_string()))
+    }
+
+    /// Enable or disable notifications for a subaccount
+    ///
+    /// Toggles whether the main account receives notifications from a subaccount.
+    ///
+    /// # Arguments
+    ///
+    /// * `sid` - The subaccount ID
+    /// * `state` - `true` to enable notifications, `false` to disable
+    ///
+    /// # Returns
+    ///
+    /// Returns `"ok"` on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let result = client.toggle_notifications_from_subaccount(123, true).await?;
+    /// // assert_eq!(result, "ok");
+    /// ```
+    pub async fn toggle_notifications_from_subaccount(
+        &self,
+        sid: u64,
+        state: bool,
+    ) -> Result<String, HttpError> {
+        let url = format!(
+            "{}{}?sid={}&state={}",
+            self.base_url(),
+            TOGGLE_NOTIFICATIONS_FROM_SUBACCOUNT,
+            sid,
+            state
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Toggle notifications from subaccount failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<String> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No result in response".to_string()))
+    }
+
     /// Get transaction log
     ///
     /// Retrieves transaction log entries for the account.

--- a/tests/unit/private_endpoints_tests.rs
+++ b/tests/unit/private_endpoints_tests.rs
@@ -1736,3 +1736,337 @@ async fn test_get_subaccounts_details_empty() {
     let details = result.unwrap();
     assert!(details.is_empty());
 }
+
+// =========================================================================
+// Subaccount Management Tests (Issue #25)
+// =========================================================================
+
+#[tokio::test]
+async fn test_create_subaccount_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": {
+            "email": "user_AAA@email.com",
+            "id": 13,
+            "is_password": false,
+            "login_enabled": false,
+            "receive_notifications": false,
+            "system_name": "user_1_4",
+            "security_keys_enabled": false,
+            "type": "subaccount",
+            "username": "user_1_4"
+        },
+        "id": 1
+    });
+
+    let mock = server
+        .mock("GET", "/api/v2/private/create_subaccount")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.create_subaccount().await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let subaccount = result.unwrap();
+    assert_eq!(subaccount.id, 13);
+    assert_eq!(subaccount.username, "user_1_4");
+    assert!(!subaccount.login_enabled);
+}
+
+#[tokio::test]
+async fn test_create_subaccount_error() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock = server
+        .mock("GET", "/api/v2/private/create_subaccount")
+        .with_status(403)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"jsonrpc": "2.0", "error": {"code": 13009, "message": "not_main_account"}, "id": 1}"#)
+        .create_async()
+        .await;
+
+    let result = client.create_subaccount().await;
+
+    mock.assert_async().await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_remove_subaccount_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": "ok",
+        "id": 1
+    });
+
+    let mock = server
+        .mock("GET", "/api/v2/private/remove_subaccount?subaccount_id=123")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.remove_subaccount(123).await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "ok");
+}
+
+#[tokio::test]
+async fn test_remove_subaccount_error() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock = server
+        .mock("GET", "/api/v2/private/remove_subaccount?subaccount_id=999")
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"jsonrpc": "2.0", "error": {"code": 13004, "message": "subaccount_not_found"}, "id": 1}"#)
+        .create_async()
+        .await;
+
+    let result = client.remove_subaccount(999).await;
+
+    mock.assert_async().await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_change_subaccount_name_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": "ok",
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            "/api/v2/private/change_subaccount_name?sid=7&name=new_user_name",
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.change_subaccount_name(7, "new_user_name").await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "ok");
+}
+
+#[tokio::test]
+async fn test_change_subaccount_name_error() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock = server
+        .mock("GET", "/api/v2/private/change_subaccount_name?sid=999&name=invalid")
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"jsonrpc": "2.0", "error": {"code": 13004, "message": "subaccount_not_found"}, "id": 1}"#)
+        .create_async()
+        .await;
+
+    let result = client.change_subaccount_name(999, "invalid").await;
+
+    mock.assert_async().await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_toggle_subaccount_login_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": "ok",
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            "/api/v2/private/toggle_subaccount_login?sid=7&state=enable",
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.toggle_subaccount_login(7, "enable").await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "ok");
+}
+
+#[tokio::test]
+async fn test_toggle_subaccount_login_error() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock = server
+        .mock("GET", "/api/v2/private/toggle_subaccount_login?sid=999&state=enable")
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"jsonrpc": "2.0", "error": {"code": 13004, "message": "subaccount_not_found"}, "id": 1}"#)
+        .create_async()
+        .await;
+
+    let result = client.toggle_subaccount_login(999, "enable").await;
+
+    mock.assert_async().await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_set_email_for_subaccount_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": "ok",
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(
+                r"/api/v2/private/set_email_for_subaccount\?sid=7&email=.*".to_string(),
+            ),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.set_email_for_subaccount(7, "user@example.com").await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "ok");
+}
+
+#[tokio::test]
+async fn test_set_email_for_subaccount_error() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(
+                r"/api/v2/private/set_email_for_subaccount\?sid=999&email=.*".to_string(),
+            ),
+        )
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"jsonrpc": "2.0", "error": {"code": 13004, "message": "subaccount_not_found"}, "id": 1}"#)
+        .create_async()
+        .await;
+
+    let result = client
+        .set_email_for_subaccount(999, "invalid@example.com")
+        .await;
+
+    mock.assert_async().await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_toggle_notifications_from_subaccount_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": "ok",
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            "/api/v2/private/toggle_notifications_from_subaccount?sid=7&state=true",
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.toggle_notifications_from_subaccount(7, true).await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "ok");
+}
+
+#[tokio::test]
+async fn test_toggle_notifications_from_subaccount_error() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock = server
+        .mock("GET", "/api/v2/private/toggle_notifications_from_subaccount?sid=999&state=false")
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"jsonrpc": "2.0", "error": {"code": 13004, "message": "subaccount_not_found"}, "id": 1}"#)
+        .create_async()
+        .await;
+
+    let result = client
+        .toggle_notifications_from_subaccount(999, false)
+        .await;
+
+    mock.assert_async().await;
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary

Implements 6 subaccount management endpoints for the Deribit HTTP client, enabling programmatic creation, removal, and configuration of subaccounts.

## Changes

- Added 6 endpoint constants to `src/constants.rs`
- Implemented 6 new methods on `DeribitHttpClient`:
  - `create_subaccount()` - Create a new subaccount
  - `remove_subaccount()` - Remove an empty subaccount
  - `change_subaccount_name()` - Change subaccount username
  - `toggle_subaccount_login()` - Enable/disable subaccount login
  - `set_email_for_subaccount()` - Assign email to subaccount
  - `toggle_notifications_from_subaccount()` - Toggle notifications
- Added 12 unit tests (success + error cases for each endpoint)

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] Benchmark tests added/updated (if applicable)
- [x] Manual testing performed (`cargo test --all-features`)

## Checklist

- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] No `.unwrap()`, `.expect()`, or panics in library code
- [x] HTTP error handling implemented
- [x] Minimal dependencies — no unnecessary crates added

Closes #25
