### PR TITLE
feat(wallet): implement address beneficiary endpoints

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -233,6 +233,18 @@ pub mod endpoints {
     pub const CHANGE_API_KEY_NAME: &str = "/private/change_api_key_name";
     /// Change API key scope
     pub const CHANGE_SCOPE_IN_API_KEY: &str = "/private/change_scope_in_api_key";
+
+    // Address Beneficiary endpoints
+    /// Save address beneficiary information
+    pub const SAVE_ADDRESS_BENEFICIARY: &str = "/private/save_address_beneficiary";
+    /// Delete address beneficiary information
+    pub const DELETE_ADDRESS_BENEFICIARY: &str = "/private/delete_address_beneficiary";
+    /// Get address beneficiary information
+    pub const GET_ADDRESS_BENEFICIARY: &str = "/private/get_address_beneficiary";
+    /// List address beneficiaries with pagination
+    pub const LIST_ADDRESS_BENEFICIARIES: &str = "/private/list_address_beneficiaries";
+    /// Set clearance originator for a deposit
+    pub const SET_CLEARANCE_ORIGINATOR: &str = "/private/set_clearance_originator";
 }
 
 /// HTTP headers

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -158,6 +158,19 @@ pub mod endpoints {
     pub const GET_SUBACCOUNTS: &str = "/private/get_subaccounts";
     /// Get subaccounts details with positions
     pub const GET_SUBACCOUNTS_DETAILS: &str = "/private/get_subaccounts_details";
+    /// Create a new subaccount
+    pub const CREATE_SUBACCOUNT: &str = "/private/create_subaccount";
+    /// Remove an empty subaccount
+    pub const REMOVE_SUBACCOUNT: &str = "/private/remove_subaccount";
+    /// Change the name of a subaccount
+    pub const CHANGE_SUBACCOUNT_NAME: &str = "/private/change_subaccount_name";
+    /// Enable or disable login for a subaccount
+    pub const TOGGLE_SUBACCOUNT_LOGIN: &str = "/private/toggle_subaccount_login";
+    /// Set email address for a subaccount
+    pub const SET_EMAIL_FOR_SUBACCOUNT: &str = "/private/set_email_for_subaccount";
+    /// Enable or disable notifications for a subaccount
+    pub const TOGGLE_NOTIFICATIONS_FROM_SUBACCOUNT: &str =
+        "/private/toggle_notifications_from_subaccount";
     /// Get transaction log
     pub const GET_TRANSACTION_LOG: &str = "/private/get_transaction_log";
     /// Get deposits

--- a/src/endpoints/private.rs
+++ b/src/endpoints/private.rs
@@ -175,6 +175,397 @@ impl DeribitHttpClient {
         })
     }
 
+    /// Create a new subaccount
+    ///
+    /// Creates a new subaccount under the main account.
+    ///
+    /// # Returns
+    ///
+    /// Returns the newly created `Subaccount` with its details.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or if the user is not a main account.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let subaccount = client.create_subaccount().await?;
+    /// // tracing::info!("Created subaccount with ID: {}", subaccount.id);
+    /// ```
+    pub async fn create_subaccount(&self) -> Result<Subaccount, HttpError> {
+        let url = format!("{}{}", self.base_url(), CREATE_SUBACCOUNT);
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Create subaccount failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<Subaccount> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No subaccount data in response".to_string()))
+    }
+
+    /// Remove an empty subaccount
+    ///
+    /// Removes a subaccount that has no open positions or pending orders.
+    ///
+    /// # Arguments
+    ///
+    /// * `subaccount_id` - The ID of the subaccount to remove
+    ///
+    /// # Returns
+    ///
+    /// Returns `"ok"` on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or if the subaccount is not empty.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let result = client.remove_subaccount(123).await?;
+    /// // assert_eq!(result, "ok");
+    /// ```
+    pub async fn remove_subaccount(&self, subaccount_id: u64) -> Result<String, HttpError> {
+        let url = format!(
+            "{}{}?subaccount_id={}",
+            self.base_url(),
+            REMOVE_SUBACCOUNT,
+            subaccount_id
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Remove subaccount failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<String> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No result in response".to_string()))
+    }
+
+    /// Change the name of a subaccount
+    ///
+    /// Updates the username for a subaccount.
+    ///
+    /// # Arguments
+    ///
+    /// * `sid` - The subaccount ID
+    /// * `name` - The new username for the subaccount
+    ///
+    /// # Returns
+    ///
+    /// Returns `"ok"` on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let result = client.change_subaccount_name(123, "new_name").await?;
+    /// // assert_eq!(result, "ok");
+    /// ```
+    pub async fn change_subaccount_name(&self, sid: u64, name: &str) -> Result<String, HttpError> {
+        let url = format!(
+            "{}{}?sid={}&name={}",
+            self.base_url(),
+            CHANGE_SUBACCOUNT_NAME,
+            sid,
+            urlencoding::encode(name)
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Change subaccount name failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<String> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No result in response".to_string()))
+    }
+
+    /// Enable or disable login for a subaccount
+    ///
+    /// Toggles whether a subaccount can log in. If login is disabled and a session
+    /// for the subaccount exists, that session will be terminated.
+    ///
+    /// # Arguments
+    ///
+    /// * `sid` - The subaccount ID
+    /// * `state` - Either `"enable"` or `"disable"`
+    ///
+    /// # Returns
+    ///
+    /// Returns `"ok"` on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let result = client.toggle_subaccount_login(123, "enable").await?;
+    /// // assert_eq!(result, "ok");
+    /// ```
+    pub async fn toggle_subaccount_login(
+        &self,
+        sid: u64,
+        state: &str,
+    ) -> Result<String, HttpError> {
+        let url = format!(
+            "{}{}?sid={}&state={}",
+            self.base_url(),
+            TOGGLE_SUBACCOUNT_LOGIN,
+            sid,
+            urlencoding::encode(state)
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Toggle subaccount login failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<String> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No result in response".to_string()))
+    }
+
+    /// Set email address for a subaccount
+    ///
+    /// Assigns an email address to a subaccount. The user will receive an email
+    /// with a confirmation link.
+    ///
+    /// # Arguments
+    ///
+    /// * `sid` - The subaccount ID
+    /// * `email` - The email address to assign
+    ///
+    /// # Returns
+    ///
+    /// Returns `"ok"` on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let result = client.set_email_for_subaccount(123, "user@example.com").await?;
+    /// // assert_eq!(result, "ok");
+    /// ```
+    pub async fn set_email_for_subaccount(
+        &self,
+        sid: u64,
+        email: &str,
+    ) -> Result<String, HttpError> {
+        let url = format!(
+            "{}{}?sid={}&email={}",
+            self.base_url(),
+            SET_EMAIL_FOR_SUBACCOUNT,
+            sid,
+            urlencoding::encode(email)
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Set email for subaccount failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<String> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No result in response".to_string()))
+    }
+
+    /// Enable or disable notifications for a subaccount
+    ///
+    /// Toggles whether the main account receives notifications from a subaccount.
+    ///
+    /// # Arguments
+    ///
+    /// * `sid` - The subaccount ID
+    /// * `state` - `true` to enable notifications, `false` to disable
+    ///
+    /// # Returns
+    ///
+    /// Returns `"ok"` on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let result = client.toggle_notifications_from_subaccount(123, true).await?;
+    /// // assert_eq!(result, "ok");
+    /// ```
+    pub async fn toggle_notifications_from_subaccount(
+        &self,
+        sid: u64,
+        state: bool,
+    ) -> Result<String, HttpError> {
+        let url = format!(
+            "{}{}?sid={}&state={}",
+            self.base_url(),
+            TOGGLE_NOTIFICATIONS_FROM_SUBACCOUNT,
+            sid,
+            state
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Toggle notifications from subaccount failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<String> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No result in response".to_string()))
+    }
+
     /// Get transaction log
     ///
     /// Retrieves transaction log entries for the account.

--- a/src/endpoints/private.rs
+++ b/src/endpoints/private.rs
@@ -4537,4 +4537,501 @@ impl DeribitHttpClient {
             .result
             .ok_or_else(|| HttpError::InvalidResponse("No API key data in response".to_string()))
     }
+
+    // ========================================================================
+    // Address Beneficiary Endpoints
+    // ========================================================================
+
+    /// Save address beneficiary information.
+    ///
+    /// Saves beneficiary information for a cryptocurrency address,
+    /// required for travel rule compliance.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The beneficiary information to save
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or the response is invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use deribit_http::DeribitHttpClient;
+    /// use deribit_http::model::SaveAddressBeneficiaryRequest;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = DeribitHttpClient::new();
+    /// let request = SaveAddressBeneficiaryRequest {
+    ///     currency: "BTC".to_string(),
+    ///     address: "bc1qtest".to_string(),
+    ///     agreed: true,
+    ///     personal: false,
+    ///     unhosted: false,
+    ///     beneficiary_vasp_name: "Test VASP".to_string(),
+    ///     beneficiary_vasp_did: "did:test:123".to_string(),
+    ///     beneficiary_address: "Test Address".to_string(),
+    ///     ..Default::default()
+    /// };
+    /// // let beneficiary = client.save_address_beneficiary(&request).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn save_address_beneficiary(
+        &self,
+        request: &crate::model::SaveAddressBeneficiaryRequest,
+    ) -> Result<crate::model::AddressBeneficiary, HttpError> {
+        let mut params = vec![
+            format!("currency={}", urlencoding::encode(&request.currency)),
+            format!("address={}", urlencoding::encode(&request.address)),
+            format!("agreed={}", request.agreed),
+            format!("personal={}", request.personal),
+            format!("unhosted={}", request.unhosted),
+            format!(
+                "beneficiary_vasp_name={}",
+                urlencoding::encode(&request.beneficiary_vasp_name)
+            ),
+            format!(
+                "beneficiary_vasp_did={}",
+                urlencoding::encode(&request.beneficiary_vasp_did)
+            ),
+            format!(
+                "beneficiary_address={}",
+                urlencoding::encode(&request.beneficiary_address)
+            ),
+        ];
+
+        if let Some(ref tag) = request.tag {
+            params.push(format!("tag={}", urlencoding::encode(tag)));
+        }
+        if let Some(ref website) = request.beneficiary_vasp_website {
+            params.push(format!(
+                "beneficiary_vasp_website={}",
+                urlencoding::encode(website)
+            ));
+        }
+        if let Some(ref first_name) = request.beneficiary_first_name {
+            params.push(format!(
+                "beneficiary_first_name={}",
+                urlencoding::encode(first_name)
+            ));
+        }
+        if let Some(ref last_name) = request.beneficiary_last_name {
+            params.push(format!(
+                "beneficiary_last_name={}",
+                urlencoding::encode(last_name)
+            ));
+        }
+        if let Some(ref company_name) = request.beneficiary_company_name {
+            params.push(format!(
+                "beneficiary_company_name={}",
+                urlencoding::encode(company_name)
+            ));
+        }
+
+        let url = format!(
+            "{}{}?{}",
+            self.base_url(),
+            SAVE_ADDRESS_BENEFICIARY,
+            params.join("&")
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Save address beneficiary failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<crate::model::AddressBeneficiary> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response.result.ok_or_else(|| {
+            HttpError::InvalidResponse("No beneficiary data in response".to_string())
+        })
+    }
+
+    /// Delete address beneficiary information.
+    ///
+    /// Removes beneficiary information for the specified address.
+    ///
+    /// # Arguments
+    ///
+    /// * `currency` - Currency symbol (e.g., "BTC", "ETH")
+    /// * `address` - The cryptocurrency address
+    /// * `tag` - Optional tag for XRP addresses
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or the response is invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = DeribitHttpClient::new();
+    /// // let result = client.delete_address_beneficiary("BTC", "bc1qtest", None).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn delete_address_beneficiary(
+        &self,
+        currency: &str,
+        address: &str,
+        tag: Option<&str>,
+    ) -> Result<String, HttpError> {
+        let mut url = format!(
+            "{}{}?currency={}&address={}",
+            self.base_url(),
+            DELETE_ADDRESS_BENEFICIARY,
+            urlencoding::encode(currency),
+            urlencoding::encode(address)
+        );
+
+        if let Some(t) = tag {
+            url.push_str(&format!("&tag={}", urlencoding::encode(t)));
+        }
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Delete address beneficiary failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<String> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No result in response".to_string()))
+    }
+
+    /// Get address beneficiary information.
+    ///
+    /// Retrieves beneficiary information for the specified address.
+    ///
+    /// # Arguments
+    ///
+    /// * `currency` - Currency symbol (e.g., "BTC", "ETH")
+    /// * `address` - The cryptocurrency address
+    /// * `tag` - Optional tag for XRP addresses
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or the response is invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = DeribitHttpClient::new();
+    /// // let beneficiary = client.get_address_beneficiary("BTC", "bc1qtest", None).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_address_beneficiary(
+        &self,
+        currency: &str,
+        address: &str,
+        tag: Option<&str>,
+    ) -> Result<crate::model::AddressBeneficiary, HttpError> {
+        let mut url = format!(
+            "{}{}?currency={}&address={}",
+            self.base_url(),
+            GET_ADDRESS_BENEFICIARY,
+            urlencoding::encode(currency),
+            urlencoding::encode(address)
+        );
+
+        if let Some(t) = tag {
+            url.push_str(&format!("&tag={}", urlencoding::encode(t)));
+        }
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get address beneficiary failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<crate::model::AddressBeneficiary> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response.result.ok_or_else(|| {
+            HttpError::InvalidResponse("No beneficiary data in response".to_string())
+        })
+    }
+
+    /// List address beneficiaries with filtering and pagination.
+    ///
+    /// Returns a paginated list of address beneficiaries with optional filters.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - Optional filtering and pagination parameters
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or the response is invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use deribit_http::DeribitHttpClient;
+    /// use deribit_http::model::ListAddressBeneficiariesRequest;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = DeribitHttpClient::new();
+    /// let request = ListAddressBeneficiariesRequest {
+    ///     currency: Some("BTC".to_string()),
+    ///     limit: Some(10),
+    ///     ..Default::default()
+    /// };
+    /// // let response = client.list_address_beneficiaries(Some(&request)).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list_address_beneficiaries(
+        &self,
+        request: Option<&crate::model::ListAddressBeneficiariesRequest>,
+    ) -> Result<crate::model::ListAddressBeneficiariesResponse, HttpError> {
+        let mut params: Vec<String> = Vec::new();
+
+        if let Some(req) = request {
+            if let Some(ref currency) = req.currency {
+                params.push(format!("currency={}", urlencoding::encode(currency)));
+            }
+            if let Some(ref address) = req.address {
+                params.push(format!("address={}", urlencoding::encode(address)));
+            }
+            if let Some(ref tag) = req.tag {
+                params.push(format!("tag={}", urlencoding::encode(tag)));
+            }
+            if let Some(created_before) = req.created_before {
+                params.push(format!("created_before={}", created_before));
+            }
+            if let Some(created_after) = req.created_after {
+                params.push(format!("created_after={}", created_after));
+            }
+            if let Some(updated_before) = req.updated_before {
+                params.push(format!("updated_before={}", updated_before));
+            }
+            if let Some(updated_after) = req.updated_after {
+                params.push(format!("updated_after={}", updated_after));
+            }
+            if let Some(personal) = req.personal {
+                params.push(format!("personal={}", personal));
+            }
+            if let Some(unhosted) = req.unhosted {
+                params.push(format!("unhosted={}", unhosted));
+            }
+            if let Some(ref vasp_name) = req.beneficiary_vasp_name {
+                params.push(format!(
+                    "beneficiary_vasp_name={}",
+                    urlencoding::encode(vasp_name)
+                ));
+            }
+            if let Some(ref vasp_did) = req.beneficiary_vasp_did {
+                params.push(format!(
+                    "beneficiary_vasp_did={}",
+                    urlencoding::encode(vasp_did)
+                ));
+            }
+            if let Some(ref vasp_website) = req.beneficiary_vasp_website {
+                params.push(format!(
+                    "beneficiary_vasp_website={}",
+                    urlencoding::encode(vasp_website)
+                ));
+            }
+            if let Some(limit) = req.limit {
+                params.push(format!("limit={}", limit));
+            }
+            if let Some(ref continuation) = req.continuation {
+                params.push(format!(
+                    "continuation={}",
+                    urlencoding::encode(continuation)
+                ));
+            }
+        }
+
+        let url = if params.is_empty() {
+            format!("{}{}", self.base_url(), LIST_ADDRESS_BENEFICIARIES)
+        } else {
+            format!(
+                "{}{}?{}",
+                self.base_url(),
+                LIST_ADDRESS_BENEFICIARIES,
+                params.join("&")
+            )
+        };
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "List address beneficiaries failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<crate::model::ListAddressBeneficiariesResponse> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response.result.ok_or_else(|| {
+            HttpError::InvalidResponse("No beneficiaries data in response".to_string())
+        })
+    }
+
+    /// Set clearance originator for a deposit.
+    ///
+    /// Sets the originator information for a deposit transaction,
+    /// required for travel rule compliance.
+    ///
+    /// # Arguments
+    ///
+    /// * `deposit_id` - Identifier of the deposit
+    /// * `originator` - Information about the originator
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or the response is invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use deribit_http::DeribitHttpClient;
+    /// use deribit_http::model::{DepositId, Originator};
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = DeribitHttpClient::new();
+    /// let deposit_id = DepositId {
+    ///     currency: "BTC".to_string(),
+    ///     user_id: 123,
+    ///     address: "2NBqqD5GRJ8wHy1PYyCXTe9ke5226FhavBz".to_string(),
+    ///     tx_hash: "230669110fdaf0a0dbcdc079b6b8b43d5af29cc73683835b9bc6b3406c065fda".to_string(),
+    /// };
+    /// let originator = Originator {
+    ///     is_personal: false,
+    ///     company_name: Some("Company Name".to_string()),
+    ///     first_name: Some("First".to_string()),
+    ///     last_name: Some("Last".to_string()),
+    ///     address: "NL, Amsterdam, Street, 1".to_string(),
+    /// };
+    /// // let result = client.set_clearance_originator(&deposit_id, &originator).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn set_clearance_originator(
+        &self,
+        deposit_id: &crate::model::DepositId,
+        originator: &crate::model::Originator,
+    ) -> Result<crate::model::ClearanceDepositResult, HttpError> {
+        let deposit_id_json = serde_json::to_string(deposit_id).map_err(|e| {
+            HttpError::InvalidResponse(format!("Failed to serialize deposit_id: {}", e))
+        })?;
+        let originator_json = serde_json::to_string(originator).map_err(|e| {
+            HttpError::InvalidResponse(format!("Failed to serialize originator: {}", e))
+        })?;
+
+        let url = format!(
+            "{}{}?deposit_id={}&originator={}",
+            self.base_url(),
+            SET_CLEARANCE_ORIGINATOR,
+            urlencoding::encode(&deposit_id_json),
+            urlencoding::encode(&originator_json)
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Set clearance originator failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<crate::model::ClearanceDepositResult> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No deposit result in response".to_string()))
+    }
 }

--- a/src/model/beneficiary.rs
+++ b/src/model/beneficiary.rs
@@ -1,0 +1,381 @@
+//! Address beneficiary models for wallet endpoints
+
+use serde::{Deserialize, Serialize};
+
+/// Address beneficiary information returned by save/get/list operations.
+///
+/// Contains all information about a beneficiary associated with
+/// a cryptocurrency address for travel rule compliance.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AddressBeneficiary {
+    /// Currency symbol (e.g., "BTC", "ETH")
+    pub currency: String,
+    /// Address in proper format for the currency
+    pub address: String,
+    /// User ID associated with this beneficiary
+    #[serde(default)]
+    pub user_id: Option<u64>,
+    /// Whether the user agreed to share information with third parties
+    pub agreed: bool,
+    /// Whether this is a personal wallet owned by the user
+    pub personal: bool,
+    /// Whether the address belongs to an unhosted wallet
+    pub unhosted: bool,
+    /// Name of the beneficiary VASP (Virtual Asset Service Provider)
+    #[serde(default)]
+    pub beneficiary_vasp_name: Option<String>,
+    /// DID (Decentralized Identifier) of the beneficiary VASP
+    #[serde(default)]
+    pub beneficiary_vasp_did: Option<String>,
+    /// Website of the beneficiary VASP
+    #[serde(default)]
+    pub beneficiary_vasp_website: Option<String>,
+    /// First name of the beneficiary (if a person)
+    #[serde(default)]
+    pub beneficiary_first_name: Option<String>,
+    /// Last name of the beneficiary (if a person)
+    #[serde(default)]
+    pub beneficiary_last_name: Option<String>,
+    /// Company name of the beneficiary (if a company)
+    #[serde(default)]
+    pub beneficiary_company_name: Option<String>,
+    /// Geographical address of the beneficiary
+    #[serde(default)]
+    pub beneficiary_address: Option<String>,
+    /// Tag for XRP addresses (optional)
+    #[serde(default)]
+    pub tag: Option<String>,
+    /// Creation timestamp in milliseconds since Unix epoch
+    #[serde(default, alias = "created")]
+    pub creation_timestamp: Option<u64>,
+    /// Update timestamp in milliseconds since Unix epoch
+    #[serde(default, alias = "updated")]
+    pub update_timestamp: Option<u64>,
+}
+
+/// Request parameters for saving an address beneficiary.
+///
+/// All fields required by the API are marked as non-optional.
+/// Optional fields use `Option<T>`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct SaveAddressBeneficiaryRequest {
+    /// Currency symbol (required)
+    pub currency: String,
+    /// Address in currency format (required)
+    pub address: String,
+    /// Tag for XRP addresses (optional)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag: Option<String>,
+    /// User agrees to share information with third parties (required)
+    pub agreed: bool,
+    /// Whether this is a personal wallet (required)
+    pub personal: bool,
+    /// Whether the address belongs to an unhosted wallet (required)
+    pub unhosted: bool,
+    /// Name of the beneficiary VASP (required)
+    pub beneficiary_vasp_name: String,
+    /// DID of the beneficiary VASP (required)
+    pub beneficiary_vasp_did: String,
+    /// Website of the beneficiary VASP (optional, required if VASP not in known list)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub beneficiary_vasp_website: Option<String>,
+    /// First name of the beneficiary (optional, for persons)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub beneficiary_first_name: Option<String>,
+    /// Last name of the beneficiary (optional, for persons)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub beneficiary_last_name: Option<String>,
+    /// Company name of the beneficiary (optional, for companies)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub beneficiary_company_name: Option<String>,
+    /// Geographical address of the beneficiary (required)
+    pub beneficiary_address: String,
+}
+
+/// Request parameters for listing address beneficiaries with filtering and pagination.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ListAddressBeneficiariesRequest {
+    /// Filter by currency symbol
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub currency: Option<String>,
+    /// Filter by address
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address: Option<String>,
+    /// Tag for XRP addresses
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag: Option<String>,
+    /// Filter by creation timestamp (before), in milliseconds
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_before: Option<u64>,
+    /// Filter by creation timestamp (after), in milliseconds
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_after: Option<u64>,
+    /// Filter by update timestamp (before), in milliseconds
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_before: Option<u64>,
+    /// Filter by update timestamp (after), in milliseconds
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_after: Option<u64>,
+    /// Filter by personal wallet flag
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub personal: Option<bool>,
+    /// Filter by unhosted wallet flag
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unhosted: Option<bool>,
+    /// Filter by beneficiary VASP name
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub beneficiary_vasp_name: Option<String>,
+    /// Filter by beneficiary VASP DID
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub beneficiary_vasp_did: Option<String>,
+    /// Filter by beneficiary VASP website
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub beneficiary_vasp_website: Option<String>,
+    /// Maximum number of results to return
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    /// Continuation token for pagination
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub continuation: Option<String>,
+}
+
+/// Paginated response for listing address beneficiaries.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ListAddressBeneficiariesResponse {
+    /// List of address beneficiaries
+    pub data: Vec<AddressBeneficiary>,
+    /// Total count of results available
+    #[serde(default)]
+    pub count: Option<u64>,
+    /// Continuation token for fetching the next page
+    #[serde(default)]
+    pub continuation: Option<String>,
+}
+
+/// Deposit identifier for `set_clearance_originator`.
+///
+/// Identifies a specific deposit transaction.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DepositId {
+    /// Currency symbol
+    pub currency: String,
+    /// User ID of the (sub)account
+    pub user_id: u64,
+    /// Deposit address in currency format
+    pub address: String,
+    /// Transaction hash in proper format for the currency
+    pub tx_hash: String,
+}
+
+/// Originator information for `set_clearance_originator`.
+///
+/// Contains details about the originator of a deposit for travel rule compliance.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Originator {
+    /// Whether the user is the originator of the deposit
+    pub is_personal: bool,
+    /// Company name (if originator is a legal entity)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub company_name: Option<String>,
+    /// First name (if originator is a person)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_name: Option<String>,
+    /// Last name (if originator is a person)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_name: Option<String>,
+    /// Geographical address of the originator
+    pub address: String,
+}
+
+/// Result of `set_clearance_originator` operation.
+///
+/// Contains the deposit information with updated clearance state.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ClearanceDepositResult {
+    /// Currency symbol
+    pub currency: String,
+    /// User ID
+    #[serde(default)]
+    pub user_id: Option<u64>,
+    /// Deposit address
+    pub address: String,
+    /// Amount of funds in the currency
+    pub amount: f64,
+    /// Deposit state: "pending", "completed", "rejected", "replaced"
+    pub state: String,
+    /// Transaction ID in proper format for the currency
+    #[serde(default)]
+    pub transaction_id: Option<String>,
+    /// Source address of the deposit
+    #[serde(default)]
+    pub source_address: Option<String>,
+    /// Timestamp when deposit was received, in milliseconds
+    #[serde(default)]
+    pub received_timestamp: Option<u64>,
+    /// Timestamp when deposit was last updated, in milliseconds
+    #[serde(default)]
+    pub updated_timestamp: Option<u64>,
+    /// Optional note
+    #[serde(default)]
+    pub note: Option<String>,
+    /// Clearance state: "in_progress", "pending_admin_decision", "pending_user_input",
+    /// "success", "failed", "cancelled", "refund_initiated", "refunded"
+    #[serde(default)]
+    pub clearance_state: Option<String>,
+    /// Refund transaction ID if applicable
+    #[serde(default)]
+    pub refund_transaction_id: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_address_beneficiary_deserialize() {
+        let json = r#"{
+            "currency": "BTC",
+            "address": "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf0uyj",
+            "user_id": 1016,
+            "agreed": true,
+            "personal": false,
+            "unhosted": false,
+            "beneficiary_vasp_name": "Money's Gone",
+            "beneficiary_vasp_did": "did:example:123456789abcdefghi",
+            "beneficiary_vasp_website": "https://example.com",
+            "beneficiary_first_name": "John",
+            "beneficiary_last_name": "Doe",
+            "beneficiary_company_name": "Example Corp",
+            "beneficiary_address": "NL, Amsterdam, Street, 1",
+            "created": 1536569522277,
+            "updated": 1536569522277
+        }"#;
+
+        let beneficiary: AddressBeneficiary = serde_json::from_str(json).unwrap();
+        assert_eq!(beneficiary.currency, "BTC");
+        assert_eq!(
+            beneficiary.address,
+            "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf0uyj"
+        );
+        assert!(beneficiary.agreed);
+        assert!(!beneficiary.personal);
+        assert!(!beneficiary.unhosted);
+        assert_eq!(
+            beneficiary.beneficiary_vasp_name,
+            Some("Money's Gone".to_string())
+        );
+        assert_eq!(beneficiary.beneficiary_first_name, Some("John".to_string()));
+        assert_eq!(beneficiary.creation_timestamp, Some(1536569522277));
+    }
+
+    #[test]
+    fn test_save_request_serialize() {
+        let request = SaveAddressBeneficiaryRequest {
+            currency: "BTC".to_string(),
+            address: "bc1qtest".to_string(),
+            tag: None,
+            agreed: true,
+            personal: false,
+            unhosted: false,
+            beneficiary_vasp_name: "Test VASP".to_string(),
+            beneficiary_vasp_did: "did:test:123".to_string(),
+            beneficiary_vasp_website: Some("https://test.com".to_string()),
+            beneficiary_first_name: Some("John".to_string()),
+            beneficiary_last_name: Some("Doe".to_string()),
+            beneficiary_company_name: None,
+            beneficiary_address: "Test Address".to_string(),
+        };
+
+        let json = serde_json::to_string(&request).unwrap();
+        assert!(json.contains("\"currency\":\"BTC\""));
+        assert!(json.contains("\"agreed\":true"));
+        assert!(!json.contains("\"tag\"")); // Should be skipped when None
+        assert!(!json.contains("beneficiary_company_name")); // Should be skipped when None
+    }
+
+    #[test]
+    fn test_list_response_deserialize() {
+        let json = r#"{
+            "data": [
+                {
+                    "currency": "BTC",
+                    "address": "bc1qtest",
+                    "agreed": true,
+                    "personal": false,
+                    "unhosted": false
+                }
+            ],
+            "continuation": "xY7T6cutS3t2B9YtaDkE6TS379oKnkzTvmEDUnEUP2Msa9xKWNNaT",
+            "count": 1
+        }"#;
+
+        let response: ListAddressBeneficiariesResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.data.len(), 1);
+        assert_eq!(response.count, Some(1));
+        assert!(response.continuation.is_some());
+    }
+
+    #[test]
+    fn test_clearance_deposit_result_deserialize() {
+        let json = r#"{
+            "currency": "BTC",
+            "user_id": 123,
+            "address": "2NBqqD5GRJ8wHy1PYyCXTe9ke5226FhavBz",
+            "amount": 0.4,
+            "state": "completed",
+            "transaction_id": "230669110fdaf0a0dbcdc079b6b8b43d5af29cc73683835b9bc6b3406c065fda",
+            "source_address": "A3BqqD5GRJ8wHy1PYyCXTe9ke5226Fha123",
+            "received_timestamp": 1550574558607,
+            "updated_timestamp": 1550574558807,
+            "note": "Note",
+            "clearance_state": "in_progress"
+        }"#;
+
+        let result: ClearanceDepositResult = serde_json::from_str(json).unwrap();
+        assert_eq!(result.currency, "BTC");
+        assert_eq!(result.user_id, Some(123));
+        let amount_diff = (result.amount - 0.4).abs();
+        assert!(amount_diff < f64::EPSILON);
+        assert_eq!(result.state, "completed");
+        assert_eq!(result.clearance_state, Some("in_progress".to_string()));
+    }
+
+    #[test]
+    fn test_deposit_id_serialize() {
+        let deposit_id = DepositId {
+            currency: "BTC".to_string(),
+            user_id: 123,
+            address: "2NBqqD5GRJ8wHy1PYyCXTe9ke5226FhavBz".to_string(),
+            tx_hash: "230669110fdaf0a0dbcdc079b6b8b43d5af29cc73683835b9bc6b3406c065fda".to_string(),
+        };
+
+        let json = serde_json::to_string(&deposit_id).unwrap();
+        assert!(json.contains("\"currency\":\"BTC\""));
+        assert!(json.contains("\"user_id\":123"));
+        assert!(json.contains("\"tx_hash\":"));
+    }
+
+    #[test]
+    fn test_originator_serialize() {
+        let originator = Originator {
+            is_personal: false,
+            company_name: Some("Company Name".to_string()),
+            first_name: Some("First".to_string()),
+            last_name: Some("Last".to_string()),
+            address: "NL, Amsterdam, Street, 1".to_string(),
+        };
+
+        let json = serde_json::to_string(&originator).unwrap();
+        assert!(json.contains("\"is_personal\":false"));
+        assert!(json.contains("\"company_name\":\"Company Name\""));
+        assert!(json.contains("\"address\":\"NL, Amsterdam, Street, 1\""));
+    }
+
+    #[test]
+    fn test_list_request_default() {
+        let request = ListAddressBeneficiariesRequest::default();
+        assert!(request.currency.is_none());
+        assert!(request.limit.is_none());
+        assert!(request.continuation.is_none());
+    }
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -5,6 +5,8 @@
 pub mod account;
 /// API key management models
 pub mod api_key;
+/// Address beneficiary models for wallet endpoints
+pub mod beneficiary;
 /// Order book models
 pub mod book;
 /// Currency and expiration models
@@ -54,6 +56,7 @@ pub mod withdrawal;
 
 pub use account::*;
 pub use api_key::*;
+pub use beneficiary::*;
 pub use book::*;
 pub use currency::*;
 pub use deposit::*;

--- a/tests/unit/beneficiary_tests.rs
+++ b/tests/unit/beneficiary_tests.rs
@@ -1,0 +1,397 @@
+//! Unit tests for address beneficiary models
+
+use deribit_http::model::{
+    AddressBeneficiary, ClearanceDepositResult, DepositId, ListAddressBeneficiariesRequest,
+    ListAddressBeneficiariesResponse, Originator, SaveAddressBeneficiaryRequest,
+};
+
+#[test]
+fn test_address_beneficiary_deserialize_full() {
+    let json = r#"{
+        "currency": "BTC",
+        "address": "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf0uyj",
+        "user_id": 1016,
+        "agreed": true,
+        "personal": false,
+        "unhosted": false,
+        "beneficiary_vasp_name": "Money's Gone",
+        "beneficiary_vasp_did": "did:example:123456789abcdefghi",
+        "beneficiary_vasp_website": "https://example.com",
+        "beneficiary_first_name": "John",
+        "beneficiary_last_name": "Doe",
+        "beneficiary_company_name": "Example Corp",
+        "beneficiary_address": "NL, Amsterdam, Street, 1",
+        "created": 1536569522277,
+        "updated": 1536569522277
+    }"#;
+
+    let beneficiary: AddressBeneficiary = serde_json::from_str(json).unwrap();
+    assert_eq!(beneficiary.currency, "BTC");
+    assert_eq!(
+        beneficiary.address,
+        "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf0uyj"
+    );
+    assert_eq!(beneficiary.user_id, Some(1016));
+    assert!(beneficiary.agreed);
+    assert!(!beneficiary.personal);
+    assert!(!beneficiary.unhosted);
+    assert_eq!(
+        beneficiary.beneficiary_vasp_name,
+        Some("Money's Gone".to_string())
+    );
+    assert_eq!(
+        beneficiary.beneficiary_vasp_did,
+        Some("did:example:123456789abcdefghi".to_string())
+    );
+    assert_eq!(beneficiary.beneficiary_first_name, Some("John".to_string()));
+    assert_eq!(beneficiary.beneficiary_last_name, Some("Doe".to_string()));
+    assert_eq!(
+        beneficiary.beneficiary_company_name,
+        Some("Example Corp".to_string())
+    );
+    assert_eq!(beneficiary.creation_timestamp, Some(1536569522277));
+    assert_eq!(beneficiary.update_timestamp, Some(1536569522277));
+}
+
+#[test]
+fn test_address_beneficiary_deserialize_minimal() {
+    let json = r#"{
+        "currency": "ETH",
+        "address": "0x123",
+        "agreed": true,
+        "personal": true,
+        "unhosted": true
+    }"#;
+
+    let beneficiary: AddressBeneficiary = serde_json::from_str(json).unwrap();
+    assert_eq!(beneficiary.currency, "ETH");
+    assert_eq!(beneficiary.address, "0x123");
+    assert!(beneficiary.agreed);
+    assert!(beneficiary.personal);
+    assert!(beneficiary.unhosted);
+    assert!(beneficiary.user_id.is_none());
+    assert!(beneficiary.beneficiary_vasp_name.is_none());
+    assert!(beneficiary.creation_timestamp.is_none());
+}
+
+#[test]
+fn test_save_request_serialize_full() {
+    let request = SaveAddressBeneficiaryRequest {
+        currency: "BTC".to_string(),
+        address: "bc1qtest".to_string(),
+        tag: Some("tag123".to_string()),
+        agreed: true,
+        personal: false,
+        unhosted: false,
+        beneficiary_vasp_name: "Test VASP".to_string(),
+        beneficiary_vasp_did: "did:test:123".to_string(),
+        beneficiary_vasp_website: Some("https://test.com".to_string()),
+        beneficiary_first_name: Some("John".to_string()),
+        beneficiary_last_name: Some("Doe".to_string()),
+        beneficiary_company_name: Some("Test Corp".to_string()),
+        beneficiary_address: "Test Address".to_string(),
+    };
+
+    let json = serde_json::to_string(&request).unwrap();
+    assert!(json.contains("\"currency\":\"BTC\""));
+    assert!(json.contains("\"address\":\"bc1qtest\""));
+    assert!(json.contains("\"tag\":\"tag123\""));
+    assert!(json.contains("\"agreed\":true"));
+    assert!(json.contains("\"personal\":false"));
+    assert!(json.contains("\"beneficiary_vasp_name\":\"Test VASP\""));
+    assert!(json.contains("\"beneficiary_company_name\":\"Test Corp\""));
+}
+
+#[test]
+fn test_save_request_serialize_minimal() {
+    let request = SaveAddressBeneficiaryRequest {
+        currency: "BTC".to_string(),
+        address: "bc1qtest".to_string(),
+        tag: None,
+        agreed: true,
+        personal: false,
+        unhosted: false,
+        beneficiary_vasp_name: "VASP".to_string(),
+        beneficiary_vasp_did: "did:test".to_string(),
+        beneficiary_vasp_website: None,
+        beneficiary_first_name: None,
+        beneficiary_last_name: None,
+        beneficiary_company_name: None,
+        beneficiary_address: "Address".to_string(),
+    };
+
+    let json = serde_json::to_string(&request).unwrap();
+    assert!(json.contains("\"currency\":\"BTC\""));
+    assert!(!json.contains("\"tag\"")); // Should be skipped when None
+    assert!(!json.contains("\"beneficiary_vasp_website\"")); // Should be skipped
+    assert!(!json.contains("\"beneficiary_first_name\"")); // Should be skipped
+    assert!(!json.contains("\"beneficiary_company_name\"")); // Should be skipped
+}
+
+#[test]
+fn test_save_request_default() {
+    let request = SaveAddressBeneficiaryRequest::default();
+    assert!(request.currency.is_empty());
+    assert!(request.address.is_empty());
+    assert!(request.tag.is_none());
+    assert!(!request.agreed);
+    assert!(!request.personal);
+    assert!(!request.unhosted);
+}
+
+#[test]
+fn test_list_request_default() {
+    let request = ListAddressBeneficiariesRequest::default();
+    assert!(request.currency.is_none());
+    assert!(request.address.is_none());
+    assert!(request.limit.is_none());
+    assert!(request.continuation.is_none());
+    assert!(request.personal.is_none());
+    assert!(request.unhosted.is_none());
+}
+
+#[test]
+fn test_list_request_serialize_with_filters() {
+    let request = ListAddressBeneficiariesRequest {
+        currency: Some("BTC".to_string()),
+        address: Some("bc1q".to_string()),
+        personal: Some(false),
+        unhosted: Some(true),
+        limit: Some(50),
+        continuation: Some("token123".to_string()),
+        ..Default::default()
+    };
+
+    let json = serde_json::to_string(&request).unwrap();
+    assert!(json.contains("\"currency\":\"BTC\""));
+    assert!(json.contains("\"personal\":false"));
+    assert!(json.contains("\"unhosted\":true"));
+    assert!(json.contains("\"limit\":50"));
+    assert!(json.contains("\"continuation\":\"token123\""));
+}
+
+#[test]
+fn test_list_response_deserialize() {
+    let json = r#"{
+        "data": [
+            {
+                "currency": "BTC",
+                "address": "bc1qtest1",
+                "agreed": true,
+                "personal": false,
+                "unhosted": false
+            },
+            {
+                "currency": "BTC",
+                "address": "bc1qtest2",
+                "agreed": true,
+                "personal": true,
+                "unhosted": false
+            }
+        ],
+        "continuation": "xY7T6cutS3t2B9YtaDkE6TS379oKnkzTvmEDUnEUP2Msa9xKWNNaT",
+        "count": 2
+    }"#;
+
+    let response: ListAddressBeneficiariesResponse = serde_json::from_str(json).unwrap();
+    assert_eq!(response.data.len(), 2);
+    assert_eq!(response.count, Some(2));
+    assert_eq!(
+        response.continuation,
+        Some("xY7T6cutS3t2B9YtaDkE6TS379oKnkzTvmEDUnEUP2Msa9xKWNNaT".to_string())
+    );
+    assert_eq!(response.data[0].address, "bc1qtest1");
+    assert_eq!(response.data[1].address, "bc1qtest2");
+    assert!(!response.data[0].personal);
+    assert!(response.data[1].personal);
+}
+
+#[test]
+fn test_list_response_deserialize_empty() {
+    let json = r#"{
+        "data": [],
+        "count": 0
+    }"#;
+
+    let response: ListAddressBeneficiariesResponse = serde_json::from_str(json).unwrap();
+    assert!(response.data.is_empty());
+    assert_eq!(response.count, Some(0));
+    assert!(response.continuation.is_none());
+}
+
+#[test]
+fn test_deposit_id_serialize() {
+    let deposit_id = DepositId {
+        currency: "BTC".to_string(),
+        user_id: 123,
+        address: "2NBqqD5GRJ8wHy1PYyCXTe9ke5226FhavBz".to_string(),
+        tx_hash: "230669110fdaf0a0dbcdc079b6b8b43d5af29cc73683835b9bc6b3406c065fda".to_string(),
+    };
+
+    let json = serde_json::to_string(&deposit_id).unwrap();
+    assert!(json.contains("\"currency\":\"BTC\""));
+    assert!(json.contains("\"user_id\":123"));
+    assert!(json.contains("\"address\":\"2NBqqD5GRJ8wHy1PYyCXTe9ke5226FhavBz\""));
+    assert!(json.contains(
+        "\"tx_hash\":\"230669110fdaf0a0dbcdc079b6b8b43d5af29cc73683835b9bc6b3406c065fda\""
+    ));
+}
+
+#[test]
+fn test_deposit_id_deserialize() {
+    let json = r#"{
+        "currency": "ETH",
+        "user_id": 456,
+        "address": "0x123456",
+        "tx_hash": "0xabcdef"
+    }"#;
+
+    let deposit_id: DepositId = serde_json::from_str(json).unwrap();
+    assert_eq!(deposit_id.currency, "ETH");
+    assert_eq!(deposit_id.user_id, 456);
+    assert_eq!(deposit_id.address, "0x123456");
+    assert_eq!(deposit_id.tx_hash, "0xabcdef");
+}
+
+#[test]
+fn test_originator_serialize_company() {
+    let originator = Originator {
+        is_personal: false,
+        company_name: Some("Company Name".to_string()),
+        first_name: None,
+        last_name: None,
+        address: "NL, Amsterdam, Street, 1".to_string(),
+    };
+
+    let json = serde_json::to_string(&originator).unwrap();
+    assert!(json.contains("\"is_personal\":false"));
+    assert!(json.contains("\"company_name\":\"Company Name\""));
+    assert!(json.contains("\"address\":\"NL, Amsterdam, Street, 1\""));
+    assert!(!json.contains("\"first_name\"")); // Should be skipped when None
+    assert!(!json.contains("\"last_name\"")); // Should be skipped when None
+}
+
+#[test]
+fn test_originator_serialize_person() {
+    let originator = Originator {
+        is_personal: true,
+        company_name: None,
+        first_name: Some("John".to_string()),
+        last_name: Some("Doe".to_string()),
+        address: "US, New York, 123 Main St".to_string(),
+    };
+
+    let json = serde_json::to_string(&originator).unwrap();
+    assert!(json.contains("\"is_personal\":true"));
+    assert!(json.contains("\"first_name\":\"John\""));
+    assert!(json.contains("\"last_name\":\"Doe\""));
+    assert!(!json.contains("\"company_name\"")); // Should be skipped when None
+}
+
+#[test]
+fn test_originator_deserialize() {
+    let json = r#"{
+        "is_personal": false,
+        "company_name": "Test Corp",
+        "first_name": "Jane",
+        "last_name": "Smith",
+        "address": "UK, London"
+    }"#;
+
+    let originator: Originator = serde_json::from_str(json).unwrap();
+    assert!(!originator.is_personal);
+    assert_eq!(originator.company_name, Some("Test Corp".to_string()));
+    assert_eq!(originator.first_name, Some("Jane".to_string()));
+    assert_eq!(originator.last_name, Some("Smith".to_string()));
+    assert_eq!(originator.address, "UK, London");
+}
+
+#[test]
+fn test_clearance_deposit_result_deserialize_full() {
+    let json = r#"{
+        "currency": "BTC",
+        "user_id": 123,
+        "address": "2NBqqD5GRJ8wHy1PYyCXTe9ke5226FhavBz",
+        "amount": 0.4,
+        "state": "completed",
+        "transaction_id": "230669110fdaf0a0dbcdc079b6b8b43d5af29cc73683835b9bc6b3406c065fda",
+        "source_address": "A3BqqD5GRJ8wHy1PYyCXTe9ke5226Fha123",
+        "received_timestamp": 1550574558607,
+        "updated_timestamp": 1550574558807,
+        "note": "Test note",
+        "clearance_state": "in_progress",
+        "refund_transaction_id": null
+    }"#;
+
+    let result: ClearanceDepositResult = serde_json::from_str(json).unwrap();
+    assert_eq!(result.currency, "BTC");
+    assert_eq!(result.user_id, Some(123));
+    assert_eq!(result.address, "2NBqqD5GRJ8wHy1PYyCXTe9ke5226FhavBz");
+    let amount_diff = (result.amount - 0.4).abs();
+    assert!(amount_diff < f64::EPSILON);
+    assert_eq!(result.state, "completed");
+    assert!(result.transaction_id.is_some());
+    assert_eq!(result.note, Some("Test note".to_string()));
+    assert_eq!(result.clearance_state, Some("in_progress".to_string()));
+    assert_eq!(result.received_timestamp, Some(1550574558607));
+    assert_eq!(result.updated_timestamp, Some(1550574558807));
+}
+
+#[test]
+fn test_clearance_deposit_result_deserialize_minimal() {
+    let json = r#"{
+        "currency": "ETH",
+        "address": "0x123",
+        "amount": 1.5,
+        "state": "pending"
+    }"#;
+
+    let result: ClearanceDepositResult = serde_json::from_str(json).unwrap();
+    assert_eq!(result.currency, "ETH");
+    assert_eq!(result.address, "0x123");
+    let amount_diff = (result.amount - 1.5).abs();
+    assert!(amount_diff < f64::EPSILON);
+    assert_eq!(result.state, "pending");
+    assert!(result.user_id.is_none());
+    assert!(result.clearance_state.is_none());
+    assert!(result.note.is_none());
+}
+
+#[test]
+fn test_clearance_states() {
+    // Test all valid clearance states deserialize correctly
+    let states = [
+        "in_progress",
+        "pending_admin_decision",
+        "pending_user_input",
+        "success",
+        "failed",
+        "cancelled",
+        "refund_initiated",
+        "refunded",
+    ];
+
+    for state in &states {
+        let json = format!(
+            r#"{{"currency": "BTC", "address": "test", "amount": 0.1, "state": "completed", "clearance_state": "{}"}}"#,
+            state
+        );
+        let result: ClearanceDepositResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(result.clearance_state, Some(state.to_string()));
+    }
+}
+
+#[test]
+fn test_deposit_states() {
+    // Test all valid deposit states
+    let states = ["pending", "completed", "rejected", "replaced"];
+
+    for state in &states {
+        let json = format!(
+            r#"{{"currency": "BTC", "address": "test", "amount": 0.1, "state": "{}"}}"#,
+            state
+        );
+        let result: ClearanceDepositResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(result.state, *state);
+    }
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -5,6 +5,7 @@
 ******************************************************************************/
 
 pub mod api_key_tests;
+pub mod beneficiary_tests;
 pub mod book_tests;
 pub mod builder_tests;
 pub mod client_tests;

--- a/tests/unit/private_endpoints_tests.rs
+++ b/tests/unit/private_endpoints_tests.rs
@@ -1736,3 +1736,337 @@ async fn test_get_subaccounts_details_empty() {
     let details = result.unwrap();
     assert!(details.is_empty());
 }
+
+// =========================================================================
+// Subaccount Management Tests (Issue #25)
+// =========================================================================
+
+#[tokio::test]
+async fn test_create_subaccount_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": {
+            "email": "user_AAA@email.com",
+            "id": 13,
+            "is_password": false,
+            "login_enabled": false,
+            "receive_notifications": false,
+            "system_name": "user_1_4",
+            "security_keys_enabled": false,
+            "type": "subaccount",
+            "username": "user_1_4"
+        },
+        "id": 1
+    });
+
+    let mock = server
+        .mock("GET", "/api/v2/private/create_subaccount")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.create_subaccount().await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let subaccount = result.unwrap();
+    assert_eq!(subaccount.id, 13);
+    assert_eq!(subaccount.username, "user_1_4");
+    assert!(!subaccount.login_enabled);
+}
+
+#[tokio::test]
+async fn test_create_subaccount_error() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock = server
+        .mock("GET", "/api/v2/private/create_subaccount")
+        .with_status(403)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"jsonrpc": "2.0", "error": {"code": 13009, "message": "not_main_account"}, "id": 1}"#)
+        .create_async()
+        .await;
+
+    let result = client.create_subaccount().await;
+
+    mock.assert_async().await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_remove_subaccount_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": "ok",
+        "id": 1
+    });
+
+    let mock = server
+        .mock("GET", "/api/v2/private/remove_subaccount?subaccount_id=123")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.remove_subaccount(123).await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "ok");
+}
+
+#[tokio::test]
+async fn test_remove_subaccount_error() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock = server
+        .mock("GET", "/api/v2/private/remove_subaccount?subaccount_id=999")
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"jsonrpc": "2.0", "error": {"code": 13004, "message": "subaccount_not_found"}, "id": 1}"#)
+        .create_async()
+        .await;
+
+    let result = client.remove_subaccount(999).await;
+
+    mock.assert_async().await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_change_subaccount_name_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": "ok",
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            "/api/v2/private/change_subaccount_name?sid=7&name=new_user_name",
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.change_subaccount_name(7, "new_user_name").await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "ok");
+}
+
+#[tokio::test]
+async fn test_change_subaccount_name_error() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock = server
+        .mock("GET", "/api/v2/private/change_subaccount_name?sid=999&name=invalid")
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"jsonrpc": "2.0", "error": {"code": 13004, "message": "subaccount_not_found"}, "id": 1}"#)
+        .create_async()
+        .await;
+
+    let result = client.change_subaccount_name(999, "invalid").await;
+
+    mock.assert_async().await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_toggle_subaccount_login_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": "ok",
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            "/api/v2/private/toggle_subaccount_login?sid=7&state=enable",
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.toggle_subaccount_login(7, "enable").await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "ok");
+}
+
+#[tokio::test]
+async fn test_toggle_subaccount_login_error() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock = server
+        .mock("GET", "/api/v2/private/toggle_subaccount_login?sid=999&state=enable")
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"jsonrpc": "2.0", "error": {"code": 13004, "message": "subaccount_not_found"}, "id": 1}"#)
+        .create_async()
+        .await;
+
+    let result = client.toggle_subaccount_login(999, "enable").await;
+
+    mock.assert_async().await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_set_email_for_subaccount_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": "ok",
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(
+                r"/api/v2/private/set_email_for_subaccount\?sid=7&email=.*".to_string(),
+            ),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.set_email_for_subaccount(7, "user@example.com").await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "ok");
+}
+
+#[tokio::test]
+async fn test_set_email_for_subaccount_error() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(
+                r"/api/v2/private/set_email_for_subaccount\?sid=999&email=.*".to_string(),
+            ),
+        )
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"jsonrpc": "2.0", "error": {"code": 13004, "message": "subaccount_not_found"}, "id": 1}"#)
+        .create_async()
+        .await;
+
+    let result = client
+        .set_email_for_subaccount(999, "invalid@example.com")
+        .await;
+
+    mock.assert_async().await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_toggle_notifications_from_subaccount_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": "ok",
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            "/api/v2/private/toggle_notifications_from_subaccount?sid=7&state=true",
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.toggle_notifications_from_subaccount(7, true).await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "ok");
+}
+
+#[tokio::test]
+async fn test_toggle_notifications_from_subaccount_error() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock = server
+        .mock("GET", "/api/v2/private/toggle_notifications_from_subaccount?sid=999&state=false")
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"jsonrpc": "2.0", "error": {"code": 13004, "message": "subaccount_not_found"}, "id": 1}"#)
+        .create_async()
+        .await;
+
+    let result = client
+        .toggle_notifications_from_subaccount(999, false)
+        .await;
+
+    mock.assert_async().await;
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary

Implements 5 address beneficiary management endpoints for travel rule compliance (closes #29).

## Endpoints Implemented

| Endpoint | Scope | Description |
|----------|-------|-------------|
| `save_address_beneficiary` | `wallet:read_write` | Save beneficiary info for an address |
| `delete_address_beneficiary` | `wallet:read_write` | Delete beneficiary info |
| `get_address_beneficiary` | `wallet:read` | Get beneficiary info for an address |
| `list_address_beneficiaries` | `wallet:read` | List all beneficiaries with pagination |
| `set_clearance_originator` | `wallet:read_write` | Set originator for a deposit |

## Changes

- **`src/constants.rs`**: Add 5 endpoint constants
- **`src/model/beneficiary.rs`**: New file with request/response models
  - `AddressBeneficiary` - Response for save/get/list operations
  - `SaveAddressBeneficiaryRequest` - Request for saving beneficiary
  - `ListAddressBeneficiariesRequest` - Request with filters and pagination
  - `ListAddressBeneficiariesResponse` - Paginated response
  - `DepositId` / `Originator` - Nested objects for set_clearance_originator
  - `ClearanceDepositResult` - Response with deposit clearance state
- **`src/model/mod.rs`**: Add module declaration and re-export
- **`src/endpoints/private.rs`**: Implement 5 async methods on `DeribitHttpClient`
- **`tests/unit/beneficiary_tests.rs`**: New file with 18 unit tests

## Note

The `get_reward_eligibility` endpoint listed in issue #29 was **skipped** because it does not exist in the Deribit API documentation. This can be added in a future PR when/if the endpoint becomes available.

## Testing

- [x] All unit tests pass (`cargo test beneficiary`)
- [x] `make lint-fix` passes
- [x] `make pre-push` passes
- [x] Documentation generated without errors