### PR TITLE
feat(endpoints): implement remaining account endpoints

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -245,6 +245,38 @@ pub mod endpoints {
     pub const LIST_ADDRESS_BENEFICIARIES: &str = "/private/list_address_beneficiaries";
     /// Set clearance originator for a deposit
     pub const SET_CLEARANCE_ORIGINATOR: &str = "/private/set_clearance_originator";
+
+    // Remaining account endpoints
+    /// Get account access log
+    pub const GET_ACCESS_LOG: &str = "/private/get_access_log";
+    /// Get user account locks
+    pub const GET_USER_LOCKS: &str = "/private/get_user_locks";
+    /// List custody accounts
+    pub const LIST_CUSTODY_ACCOUNTS: &str = "/private/list_custody_accounts";
+    /// Simulate portfolio margin
+    pub const SIMULATE_PORTFOLIO: &str = "/private/simulate_portfolio";
+    /// PME margin simulation
+    pub const PME_SIMULATE: &str = "/private/pme/simulate";
+    /// Change margin model
+    pub const CHANGE_MARGIN_MODEL: &str = "/private/change_margin_model";
+    /// Set self-trading configuration
+    pub const SET_SELF_TRADING_CONFIG: &str = "/private/set_self_trading_config";
+    /// Set disabled trading products
+    pub const SET_DISABLED_TRADING_PRODUCTS: &str = "/private/set_disabled_trading_products";
+    /// Get public announcements
+    pub const GET_ANNOUNCEMENTS: &str = "/public/get_announcements";
+    /// Get new (unread) announcements
+    pub const GET_NEW_ANNOUNCEMENTS: &str = "/private/get_new_announcements";
+    /// Mark announcement as read
+    pub const SET_ANNOUNCEMENT_AS_READ: &str = "/private/set_announcement_as_read";
+    /// Enable affiliate program
+    pub const ENABLE_AFFILIATE_PROGRAM: &str = "/private/enable_affiliate_program";
+    /// Get affiliate program information
+    pub const GET_AFFILIATE_PROGRAM_INFO: &str = "/private/get_affiliate_program_info";
+    /// Set email language preference
+    pub const SET_EMAIL_LANGUAGE: &str = "/private/set_email_language";
+    /// Get email language preference
+    pub const GET_EMAIL_LANGUAGE: &str = "/private/get_email_language";
 }
 
 /// HTTP headers

--- a/src/endpoints/private.rs
+++ b/src/endpoints/private.rs
@@ -5034,4 +5034,712 @@ impl DeribitHttpClient {
             .result
             .ok_or_else(|| HttpError::InvalidResponse("No deposit result in response".to_string()))
     }
+
+    /// Get account access log
+    ///
+    /// Retrieves the account access history showing login attempts and API access.
+    ///
+    /// # Arguments
+    ///
+    /// * `count` - Number of entries to retrieve (optional, default 10)
+    /// * `offset` - Offset for pagination (optional, default 0)
+    ///
+    pub async fn get_access_log(
+        &self,
+        count: Option<u32>,
+        offset: Option<u32>,
+    ) -> Result<crate::model::AccessLogResponse, HttpError> {
+        let mut query_params = Vec::new();
+
+        if let Some(count) = count {
+            query_params.push(format!("count={}", count));
+        }
+
+        if let Some(offset) = offset {
+            query_params.push(format!("offset={}", offset));
+        }
+
+        let query_string = if query_params.is_empty() {
+            String::new()
+        } else {
+            format!("?{}", query_params.join("&"))
+        };
+
+        let url = format!(
+            "{}{}{}",
+            self.base_url(),
+            crate::constants::endpoints::GET_ACCESS_LOG,
+            query_string
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get access log failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<crate::model::AccessLogResponse> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No access log data in response".to_string()))
+    }
+
+    /// Get user account locks
+    ///
+    /// Retrieves information about any locks on the user's account.
+    ///
+    pub async fn get_user_locks(&self) -> Result<Vec<crate::model::UserLock>, HttpError> {
+        let url = format!(
+            "{}{}",
+            self.base_url(),
+            crate::constants::endpoints::GET_USER_LOCKS
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get user locks failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<Vec<crate::model::UserLock>> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No user locks data in response".to_string()))
+    }
+
+    /// List custody accounts
+    ///
+    /// Retrieves the list of custody accounts for the specified currency.
+    ///
+    /// # Arguments
+    ///
+    /// * `currency` - Currency symbol (BTC, ETH, etc.)
+    ///
+    pub async fn list_custody_accounts(
+        &self,
+        currency: &str,
+    ) -> Result<Vec<crate::model::CustodyAccount>, HttpError> {
+        let url = format!(
+            "{}{}?currency={}",
+            self.base_url(),
+            crate::constants::endpoints::LIST_CUSTODY_ACCOUNTS,
+            urlencoding::encode(currency)
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "List custody accounts failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<Vec<crate::model::CustodyAccount>> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response.result.ok_or_else(|| {
+            HttpError::InvalidResponse("No custody accounts data in response".to_string())
+        })
+    }
+
+    /// Simulate portfolio margin
+    ///
+    /// Simulates portfolio margin for hypothetical positions.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - Simulation request parameters
+    ///
+    pub async fn simulate_portfolio(
+        &self,
+        request: crate::model::SimulatePortfolioRequest,
+    ) -> Result<crate::model::SimulatePortfolioResponse, HttpError> {
+        let mut query_params = vec![format!(
+            "currency={}",
+            urlencoding::encode(&request.currency)
+        )];
+
+        if let Some(add_positions) = request.add_positions {
+            query_params.push(format!("add_positions={}", add_positions));
+        }
+
+        if let Some(ref positions) = request.simulated_positions {
+            let positions_json = serde_json::to_string(positions)
+                .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+            query_params.push(format!(
+                "simulated_positions={}",
+                urlencoding::encode(&positions_json)
+            ));
+        }
+
+        let url = format!(
+            "{}{}?{}",
+            self.base_url(),
+            crate::constants::endpoints::SIMULATE_PORTFOLIO,
+            query_params.join("&")
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Simulate portfolio failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<crate::model::SimulatePortfolioResponse> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response.result.ok_or_else(|| {
+            HttpError::InvalidResponse("No portfolio simulation data in response".to_string())
+        })
+    }
+
+    /// PME margin simulation
+    ///
+    /// Simulates Portfolio Margin Engine (PME) margin for the specified currency.
+    ///
+    /// # Arguments
+    ///
+    /// * `currency` - Currency symbol (BTC, ETH, etc.)
+    ///
+    pub async fn pme_simulate(
+        &self,
+        currency: &str,
+    ) -> Result<crate::model::PmeSimulateResponse, HttpError> {
+        let url = format!(
+            "{}{}?currency={}",
+            self.base_url(),
+            crate::constants::endpoints::PME_SIMULATE,
+            urlencoding::encode(currency)
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "PME simulate failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<crate::model::PmeSimulateResponse> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response.result.ok_or_else(|| {
+            HttpError::InvalidResponse("No PME simulation data in response".to_string())
+        })
+    }
+
+    /// Change margin model
+    ///
+    /// Changes the margin model for the account or a specific user.
+    ///
+    /// # Arguments
+    ///
+    /// * `margin_model` - The new margin model to set
+    /// * `user_id` - Optional user ID (for main account operating on subaccounts)
+    /// * `dry_run` - Optional flag to simulate the change without applying it
+    ///
+    pub async fn change_margin_model(
+        &self,
+        margin_model: crate::model::MarginModel,
+        user_id: Option<u64>,
+        dry_run: Option<bool>,
+    ) -> Result<crate::model::ChangeMarginModelResponse, HttpError> {
+        let mut query_params = vec![format!("margin_model={}", margin_model.as_str())];
+
+        if let Some(user_id) = user_id {
+            query_params.push(format!("user_id={}", user_id));
+        }
+
+        if let Some(dry_run) = dry_run {
+            query_params.push(format!("dry_run={}", dry_run));
+        }
+
+        let url = format!(
+            "{}{}?{}",
+            self.base_url(),
+            crate::constants::endpoints::CHANGE_MARGIN_MODEL,
+            query_params.join("&")
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Change margin model failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<crate::model::ChangeMarginModelResponse> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response.result.ok_or_else(|| {
+            HttpError::InvalidResponse("No margin model change data in response".to_string())
+        })
+    }
+
+    /// Set self-trading configuration
+    ///
+    /// Configures self-trading prevention settings for the account.
+    ///
+    /// # Arguments
+    ///
+    /// * `mode` - Self-trading prevention mode
+    /// * `extended_to_subaccounts` - Whether to extend the config to subaccounts
+    /// * `block_rfq_self_match_prevention` - Optional RFQ self-match prevention setting
+    ///
+    pub async fn set_self_trading_config(
+        &self,
+        mode: crate::model::SelfTradingMode,
+        extended_to_subaccounts: bool,
+        block_rfq_self_match_prevention: Option<bool>,
+    ) -> Result<bool, HttpError> {
+        let mut query_params = vec![
+            format!("mode={}", mode.as_str()),
+            format!("extended_to_subaccounts={}", extended_to_subaccounts),
+        ];
+
+        if let Some(block_rfq) = block_rfq_self_match_prevention {
+            query_params.push(format!("block_rfq_self_match_prevention={}", block_rfq));
+        }
+
+        let url = format!(
+            "{}{}?{}",
+            self.base_url(),
+            crate::constants::endpoints::SET_SELF_TRADING_CONFIG,
+            query_params.join("&")
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Set self trading config failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<String> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        Ok(api_response.result.map(|s| s == "ok").unwrap_or(true))
+    }
+
+    /// Set disabled trading products
+    ///
+    /// Disables specific trading products for a user.
+    ///
+    /// # Arguments
+    ///
+    /// * `trading_products` - List of trading products to disable
+    /// * `user_id` - User ID to apply the setting to
+    ///
+    pub async fn set_disabled_trading_products(
+        &self,
+        trading_products: &[crate::model::TradingProduct],
+        user_id: u64,
+    ) -> Result<bool, HttpError> {
+        let products: Vec<&str> = trading_products.iter().map(|p| p.as_str()).collect();
+        let products_json = serde_json::to_string(&products)
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        let url = format!(
+            "{}{}?trading_products={}&user_id={}",
+            self.base_url(),
+            crate::constants::endpoints::SET_DISABLED_TRADING_PRODUCTS,
+            urlencoding::encode(&products_json),
+            user_id
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Set disabled trading products failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<String> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        Ok(api_response.result.map(|s| s == "ok").unwrap_or(true))
+    }
+
+    /// Get new (unread) announcements
+    ///
+    /// Retrieves announcements that have not been marked as read.
+    ///
+    pub async fn get_new_announcements(
+        &self,
+    ) -> Result<Vec<crate::model::Announcement>, HttpError> {
+        let url = format!(
+            "{}{}",
+            self.base_url(),
+            crate::constants::endpoints::GET_NEW_ANNOUNCEMENTS
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get new announcements failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<Vec<crate::model::Announcement>> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response.result.ok_or_else(|| {
+            HttpError::InvalidResponse("No new announcements data in response".to_string())
+        })
+    }
+
+    /// Mark announcement as read
+    ///
+    /// Marks a specific announcement as read so it won't appear in new announcements.
+    ///
+    /// # Arguments
+    ///
+    /// * `announcement_id` - ID of the announcement to mark as read
+    ///
+    pub async fn set_announcement_as_read(&self, announcement_id: u64) -> Result<bool, HttpError> {
+        let url = format!(
+            "{}{}?announcement_id={}",
+            self.base_url(),
+            crate::constants::endpoints::SET_ANNOUNCEMENT_AS_READ,
+            announcement_id
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Set announcement as read failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<String> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        Ok(api_response.result.map(|s| s == "ok").unwrap_or(true))
+    }
+
+    /// Enable affiliate program
+    ///
+    /// Enables the affiliate program for the user's account.
+    ///
+    pub async fn enable_affiliate_program(&self) -> Result<bool, HttpError> {
+        let url = format!(
+            "{}{}",
+            self.base_url(),
+            crate::constants::endpoints::ENABLE_AFFILIATE_PROGRAM
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Enable affiliate program failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<String> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        Ok(api_response.result.map(|s| s == "ok").unwrap_or(true))
+    }
+
+    /// Get affiliate program information
+    ///
+    /// Retrieves information about the user's affiliate program status.
+    ///
+    pub async fn get_affiliate_program_info(
+        &self,
+    ) -> Result<crate::model::AffiliateProgramInfo, HttpError> {
+        let url = format!(
+            "{}{}",
+            self.base_url(),
+            crate::constants::endpoints::GET_AFFILIATE_PROGRAM_INFO
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get affiliate program info failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<crate::model::AffiliateProgramInfo> =
+            response
+                .json()
+                .await
+                .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response.result.ok_or_else(|| {
+            HttpError::InvalidResponse("No affiliate program info in response".to_string())
+        })
+    }
+
+    /// Set email language preference
+    ///
+    /// Sets the preferred language for email communications.
+    ///
+    /// # Arguments
+    ///
+    /// * `language` - The language to set for emails
+    ///
+    pub async fn set_email_language(
+        &self,
+        language: crate::model::EmailLanguage,
+    ) -> Result<bool, HttpError> {
+        let url = format!(
+            "{}{}?language={}",
+            self.base_url(),
+            crate::constants::endpoints::SET_EMAIL_LANGUAGE,
+            language.as_str()
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Set email language failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<String> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        Ok(api_response.result.map(|s| s == "ok").unwrap_or(true))
+    }
+
+    /// Get email language preference
+    ///
+    /// Retrieves the current email language preference.
+    ///
+    pub async fn get_email_language(&self) -> Result<String, HttpError> {
+        let url = format!(
+            "{}{}",
+            self.base_url(),
+            crate::constants::endpoints::GET_EMAIL_LANGUAGE
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get email language failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<String> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No email language in response".to_string()))
+    }
 }

--- a/src/endpoints/public.rs
+++ b/src/endpoints/public.rs
@@ -2674,4 +2674,91 @@ impl DeribitHttpClient {
             .result
             .ok_or_else(|| HttpError::InvalidResponse("No order book data in response".to_string()))
     }
+
+    /// Get platform announcements
+    ///
+    /// Retrieves announcements from the platform. Default start_timestamp is current time,
+    /// count must be between 1 and 50 (default is 5).
+    ///
+    /// # Arguments
+    ///
+    /// * `count` - Number of announcements to retrieve (1-50, default 5)
+    /// * `start_timestamp` - Optional timestamp to start from in milliseconds
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use deribit_http::DeribitHttpClient;
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = DeribitHttpClient::new();
+    /// let announcements = client.get_announcements(Some(10), None).await?;
+    /// for announcement in announcements {
+    ///     println!("Announcement: {}", announcement.title);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_announcements(
+        &self,
+        count: Option<u32>,
+        start_timestamp: Option<u64>,
+    ) -> Result<Vec<crate::model::Announcement>, HttpError> {
+        let mut query_params = Vec::new();
+
+        if let Some(count) = count {
+            query_params.push(format!("count={}", count));
+        }
+
+        if let Some(ts) = start_timestamp {
+            query_params.push(format!("start_timestamp={}", ts));
+        }
+
+        let query_string = if query_params.is_empty() {
+            String::new()
+        } else {
+            format!("?{}", query_params.join("&"))
+        };
+
+        let url = format!(
+            "{}{}{}",
+            self.base_url(),
+            crate::constants::endpoints::GET_ANNOUNCEMENTS,
+            query_string
+        );
+
+        let response = self
+            .http_client()
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| HttpError::NetworkError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get announcements failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<Vec<crate::model::Announcement>> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No announcements in response".to_string()))
+    }
 }

--- a/src/model/access_log.rs
+++ b/src/model/access_log.rs
@@ -1,0 +1,81 @@
+//! Access log models for Deribit API
+//!
+//! This module contains types for account access history.
+
+use serde::{Deserialize, Serialize};
+
+/// Access log entry representing a single access event
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AccessLogEntry {
+    /// Timestamp of the access event in milliseconds
+    pub timestamp: u64,
+    /// IP address from which the access occurred
+    pub ip: String,
+    /// Action performed (e.g., "login", "api_call")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action: Option<String>,
+    /// Result of the action (e.g., "success", "failure")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<String>,
+    /// Country code derived from IP address
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub country: Option<String>,
+    /// City derived from IP address
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub city: Option<String>,
+    /// Log entry ID
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<u64>,
+    /// Additional data associated with the access event
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+/// Response for get_access_log endpoint
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AccessLogResponse {
+    /// List of access log entries
+    pub data: Vec<AccessLogEntry>,
+    /// Continuation token for pagination
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub continuation: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_access_log_entry_deserialization() {
+        let json = r#"{
+            "timestamp": 1550058362000,
+            "ip": "192.168.1.1",
+            "action": "login",
+            "result": "success",
+            "country": "US",
+            "city": "New York"
+        }"#;
+
+        let entry: AccessLogEntry = serde_json::from_str(json).expect("Failed to parse");
+        assert_eq!(entry.timestamp, 1550058362000);
+        assert_eq!(entry.ip, "192.168.1.1");
+        assert_eq!(entry.action, Some("login".to_string()));
+    }
+
+    #[test]
+    fn test_access_log_response_deserialization() {
+        let json = r#"{
+            "data": [
+                {
+                    "timestamp": 1000000,
+                    "ip": "10.0.0.1"
+                }
+            ],
+            "continuation": "abc123"
+        }"#;
+
+        let response: AccessLogResponse = serde_json::from_str(json).expect("Failed to parse");
+        assert_eq!(response.data.len(), 1);
+        assert_eq!(response.continuation, Some("abc123".to_string()));
+    }
+}

--- a/src/model/affiliate.rs
+++ b/src/model/affiliate.rs
@@ -1,0 +1,52 @@
+//! Affiliate program models for Deribit API
+//!
+//! This module contains types for affiliate program information.
+
+use serde::{Deserialize, Serialize};
+
+/// Affiliate program information
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AffiliateProgramInfo {
+    /// Whether the affiliate program is enabled
+    pub is_enabled: bool,
+    /// Affiliate referral link
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub link: Option<String>,
+    /// Number of referred users
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub number_of_affiliates: Option<u64>,
+    /// Total received commission amount
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub received: Option<f64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_affiliate_info_deserialization() {
+        let json = r#"{
+            "is_enabled": true,
+            "link": "https://deribit.com/?ref=ABC123",
+            "number_of_affiliates": 5,
+            "received": 0.001
+        }"#;
+
+        let info: AffiliateProgramInfo = serde_json::from_str(json).expect("Failed to parse");
+        assert!(info.is_enabled);
+        assert!(info.link.is_some());
+        assert_eq!(info.number_of_affiliates, Some(5));
+    }
+
+    #[test]
+    fn test_affiliate_info_disabled() {
+        let json = r#"{
+            "is_enabled": false
+        }"#;
+
+        let info: AffiliateProgramInfo = serde_json::from_str(json).expect("Failed to parse");
+        assert!(!info.is_enabled);
+        assert!(info.link.is_none());
+    }
+}

--- a/src/model/announcement.rs
+++ b/src/model/announcement.rs
@@ -1,0 +1,61 @@
+//! Announcement models for Deribit API
+//!
+//! This module contains types for platform announcements.
+
+use serde::{Deserialize, Serialize};
+
+/// Platform announcement
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Announcement {
+    /// Announcement ID
+    pub id: u64,
+    /// Announcement title
+    pub title: String,
+    /// Announcement body/content in HTML format
+    pub body: String,
+    /// Publication timestamp in milliseconds
+    pub publication_timestamp: u64,
+    /// Whether the announcement is important
+    pub important: bool,
+    /// Optional action URL
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_announcement_deserialization() {
+        let json = r#"{
+            "id": 1550058362418,
+            "title": "Test Announcement",
+            "body": "<p>Test content</p>",
+            "publication_timestamp": 1550058362000,
+            "important": true,
+            "action": "https://deribit.com"
+        }"#;
+
+        let announcement: Announcement = serde_json::from_str(json).expect("Failed to parse");
+        assert_eq!(announcement.id, 1550058362418);
+        assert_eq!(announcement.title, "Test Announcement");
+        assert!(announcement.important);
+        assert!(announcement.action.is_some());
+    }
+
+    #[test]
+    fn test_announcement_without_action() {
+        let json = r#"{
+            "id": 123,
+            "title": "Simple",
+            "body": "Content",
+            "publication_timestamp": 1000000,
+            "important": false
+        }"#;
+
+        let announcement: Announcement = serde_json::from_str(json).expect("Failed to parse");
+        assert_eq!(announcement.id, 123);
+        assert!(announcement.action.is_none());
+    }
+}

--- a/src/model/custody.rs
+++ b/src/model/custody.rs
@@ -1,0 +1,59 @@
+//! Custody account models for Deribit API
+//!
+//! This module contains types for custody accounts.
+
+use serde::{Deserialize, Serialize};
+
+/// Custody account information
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CustodyAccount {
+    /// Custody account ID
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// Currency of the custody account
+    pub currency: String,
+    /// Current balance
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub balance: Option<f64>,
+    /// Custody provider name
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    /// Account status
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    /// Account creation timestamp in milliseconds
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub creation_timestamp: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_custody_account_deserialization() {
+        let json = r#"{
+            "id": "custody_123",
+            "currency": "BTC",
+            "balance": 1.5,
+            "provider": "fireblocks",
+            "status": "active"
+        }"#;
+
+        let account: CustodyAccount = serde_json::from_str(json).expect("Failed to parse");
+        assert_eq!(account.currency, "BTC");
+        assert_eq!(account.balance, Some(1.5));
+        assert_eq!(account.provider, Some("fireblocks".to_string()));
+    }
+
+    #[test]
+    fn test_custody_account_minimal() {
+        let json = r#"{
+            "currency": "ETH"
+        }"#;
+
+        let account: CustodyAccount = serde_json::from_str(json).expect("Failed to parse");
+        assert_eq!(account.currency, "ETH");
+        assert!(account.id.is_none());
+    }
+}

--- a/src/model/email_settings.rs
+++ b/src/model/email_settings.rs
@@ -1,0 +1,78 @@
+//! Email settings models for Deribit API
+//!
+//! This module contains types for email language preferences.
+
+use serde::{Deserialize, Serialize};
+
+/// Supported email languages
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EmailLanguage {
+    /// English
+    En,
+    /// Korean
+    Ko,
+    /// Chinese
+    Zh,
+    /// Japanese
+    Ja,
+    /// Russian
+    Ru,
+    /// Spanish
+    Es,
+    /// Portuguese
+    Pt,
+    /// Turkish
+    Tr,
+    /// Vietnamese
+    Vi,
+}
+
+impl EmailLanguage {
+    /// Returns the language code as a string
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::En => "en",
+            Self::Ko => "ko",
+            Self::Zh => "zh",
+            Self::Ja => "ja",
+            Self::Ru => "ru",
+            Self::Es => "es",
+            Self::Pt => "pt",
+            Self::Tr => "tr",
+            Self::Vi => "vi",
+        }
+    }
+}
+
+impl std::fmt::Display for EmailLanguage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_email_language_serialization() {
+        let lang = EmailLanguage::En;
+        let json = serde_json::to_string(&lang).expect("Failed to serialize");
+        assert_eq!(json, "\"en\"");
+    }
+
+    #[test]
+    fn test_email_language_deserialization() {
+        let json = "\"ko\"";
+        let lang: EmailLanguage = serde_json::from_str(json).expect("Failed to parse");
+        assert_eq!(lang, EmailLanguage::Ko);
+    }
+
+    #[test]
+    fn test_email_language_as_str() {
+        assert_eq!(EmailLanguage::Ja.as_str(), "ja");
+        assert_eq!(EmailLanguage::Ru.as_str(), "ru");
+    }
+}

--- a/src/model/margin_model.rs
+++ b/src/model/margin_model.rs
@@ -1,0 +1,86 @@
+//! Margin model types for Deribit API
+//!
+//! This module contains types for margin model configuration.
+
+use serde::{Deserialize, Serialize};
+
+/// Available margin models
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MarginModel {
+    /// Cross Portfolio Margin
+    CrossPm,
+    /// Segregated Portfolio Margin
+    SegregatedPm,
+    /// Cross Standard Margin
+    CrossSm,
+    /// Segregated Standard Margin
+    SegregatedSm,
+}
+
+impl MarginModel {
+    /// Returns the margin model as a string for API requests
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::CrossPm => "cross_pm",
+            Self::SegregatedPm => "segregated_pm",
+            Self::CrossSm => "cross_sm",
+            Self::SegregatedSm => "segregated_sm",
+        }
+    }
+}
+
+impl std::fmt::Display for MarginModel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+/// Response for change_margin_model endpoint
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ChangeMarginModelResponse {
+    /// The new margin model
+    pub margin_model: String,
+    /// Whether the change was successful
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub success: Option<bool>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_margin_model_serialization() {
+        let model = MarginModel::CrossPm;
+        let json = serde_json::to_string(&model).expect("Failed to serialize");
+        assert_eq!(json, "\"cross_pm\"");
+    }
+
+    #[test]
+    fn test_margin_model_deserialization() {
+        let json = "\"segregated_pm\"";
+        let model: MarginModel = serde_json::from_str(json).expect("Failed to parse");
+        assert_eq!(model, MarginModel::SegregatedPm);
+    }
+
+    #[test]
+    fn test_margin_model_as_str() {
+        assert_eq!(MarginModel::CrossSm.as_str(), "cross_sm");
+        assert_eq!(MarginModel::SegregatedSm.as_str(), "segregated_sm");
+    }
+
+    #[test]
+    fn test_change_margin_model_response() {
+        let json = r#"{
+            "margin_model": "cross_pm",
+            "success": true
+        }"#;
+
+        let response: ChangeMarginModelResponse =
+            serde_json::from_str(json).expect("Failed to parse");
+        assert_eq!(response.margin_model, "cross_pm");
+        assert_eq!(response.success, Some(true));
+    }
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,8 +1,14 @@
 //! Model definitions for HTTP client
 
 // HTTP-specific models
+/// Access log models for account history
+pub mod access_log;
 /// Account-related models and structures
 pub mod account;
+/// Affiliate program models
+pub mod affiliate;
+/// Announcement models
+pub mod announcement;
 /// API key management models
 pub mod api_key;
 /// Address beneficiary models for wallet endpoints
@@ -11,8 +17,12 @@ pub mod beneficiary;
 pub mod book;
 /// Currency and expiration models
 pub mod currency;
+/// Custody account models
+pub mod custody;
 /// Deposit-related models
 pub mod deposit;
+/// Email settings models
+pub mod email_settings;
 /// Fee calculation and structure models
 pub mod fee;
 /// Funding rate models
@@ -21,6 +31,8 @@ pub mod funding;
 pub mod index;
 /// Instrument definition models
 pub mod instrument;
+/// Margin model configuration
+pub mod margin_model;
 /// Mass quote models
 pub mod mass_quote;
 /// Option contract models and types
@@ -29,18 +41,24 @@ pub mod option;
 pub mod order;
 /// Other miscellaneous models
 pub mod other;
+/// Portfolio simulation models
+pub mod portfolio_simulation;
 /// Position models
 pub mod position;
 /// Request models and structures
 pub mod request;
 /// Response models and structures
 pub mod response;
+/// Self-trading configuration models
+pub mod self_trading;
 /// Settlement models
 pub mod settlement;
 /// Ticker data models
 pub mod ticker;
 /// Trade execution models
 pub mod trade;
+/// Trading products configuration
+pub mod trading_products;
 /// TradingView chart models
 pub mod tradingview;
 /// Transaction log models
@@ -51,32 +69,44 @@ pub mod transfer;
 pub mod trigger;
 /// Common type definitions
 pub mod types;
+/// User lock models
+pub mod user_lock;
 /// Withdrawal models
 pub mod withdrawal;
 
+pub use access_log::*;
 pub use account::*;
+pub use affiliate::*;
+pub use announcement::*;
 pub use api_key::*;
 pub use beneficiary::*;
 pub use book::*;
 pub use currency::*;
+pub use custody::*;
 pub use deposit::*;
+pub use email_settings::*;
 pub use fee::*;
 pub use funding::*;
 pub use index::*;
 pub use instrument::*;
+pub use margin_model::*;
 pub use mass_quote::*;
 pub use option::*;
 pub use order::*;
 pub use other::*;
+pub use portfolio_simulation::*;
 pub use position::*;
 pub use request::*;
 pub use response::*;
+pub use self_trading::*;
 pub use settlement::*;
 pub use ticker::*;
 pub use trade::*;
+pub use trading_products::*;
 pub use tradingview::*;
 pub use transaction::*;
 pub use transfer::*;
 pub use trigger::*;
 pub use types::*;
+pub use user_lock::*;
 pub use withdrawal::*;

--- a/src/model/portfolio_simulation.rs
+++ b/src/model/portfolio_simulation.rs
@@ -1,0 +1,133 @@
+//! Portfolio simulation models for Deribit API
+//!
+//! This module contains types for portfolio margin simulation.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Request for simulate_portfolio endpoint
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SimulatePortfolioRequest {
+    /// Currency for the simulation (e.g., "BTC", "ETH")
+    pub currency: String,
+    /// Whether to add simulated positions to existing positions
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub add_positions: Option<bool>,
+    /// Map of instrument names to simulated position sizes
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub simulated_positions: Option<HashMap<String, f64>>,
+}
+
+impl SimulatePortfolioRequest {
+    /// Creates a new simulation request for the specified currency
+    #[must_use]
+    pub fn new(currency: impl Into<String>) -> Self {
+        Self {
+            currency: currency.into(),
+            add_positions: None,
+            simulated_positions: None,
+        }
+    }
+
+    /// Sets whether to add positions to existing ones
+    #[must_use]
+    pub fn with_add_positions(mut self, add: bool) -> Self {
+        self.add_positions = Some(add);
+        self
+    }
+
+    /// Sets the simulated positions
+    #[must_use]
+    pub fn with_simulated_positions(mut self, positions: HashMap<String, f64>) -> Self {
+        self.simulated_positions = Some(positions);
+        self
+    }
+}
+
+/// Response for simulate_portfolio endpoint
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SimulatePortfolioResponse {
+    /// Projected initial margin
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub projected_initial_margin: Option<f64>,
+    /// Projected maintenance margin
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub projected_maintenance_margin: Option<f64>,
+    /// Projected delta total
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub projected_delta_total: Option<f64>,
+    /// Change in margin
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub margin_change: Option<f64>,
+    /// Available funds after simulation
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub available_funds: Option<f64>,
+    /// Additional margin data
+    #[serde(flatten)]
+    pub additional: HashMap<String, serde_json::Value>,
+}
+
+/// Response for PME (Portfolio Margin Engine) simulation
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PmeSimulateResponse {
+    /// Total projected margin
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub projected_margin: Option<f64>,
+    /// Liquidation price estimate
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub liquidation_price: Option<f64>,
+    /// Risk metrics
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub risk_value: Option<f64>,
+    /// Additional PME data
+    #[serde(flatten)]
+    pub additional: HashMap<String, serde_json::Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_simulate_portfolio_request_builder() {
+        let mut positions = HashMap::new();
+        positions.insert("BTC-PERPETUAL".to_string(), 1.0);
+
+        let request = SimulatePortfolioRequest::new("BTC")
+            .with_add_positions(true)
+            .with_simulated_positions(positions);
+
+        assert_eq!(request.currency, "BTC");
+        assert_eq!(request.add_positions, Some(true));
+        assert!(request.simulated_positions.is_some());
+    }
+
+    #[test]
+    fn test_simulate_portfolio_response_deserialization() {
+        let json = r#"{
+            "projected_initial_margin": 0.05,
+            "projected_maintenance_margin": 0.03,
+            "projected_delta_total": 1.5,
+            "margin_change": 0.01,
+            "available_funds": 0.95
+        }"#;
+
+        let response: SimulatePortfolioResponse =
+            serde_json::from_str(json).expect("Failed to parse");
+        assert_eq!(response.projected_initial_margin, Some(0.05));
+        assert_eq!(response.projected_maintenance_margin, Some(0.03));
+    }
+
+    #[test]
+    fn test_pme_simulate_response_deserialization() {
+        let json = r#"{
+            "projected_margin": 0.1,
+            "liquidation_price": 50000.0,
+            "risk_value": 0.05
+        }"#;
+
+        let response: PmeSimulateResponse = serde_json::from_str(json).expect("Failed to parse");
+        assert_eq!(response.projected_margin, Some(0.1));
+        assert_eq!(response.liquidation_price, Some(50000.0));
+    }
+}

--- a/src/model/self_trading.rs
+++ b/src/model/self_trading.rs
@@ -1,0 +1,77 @@
+//! Self-trading configuration models for Deribit API
+//!
+//! This module contains types for self-trading prevention configuration.
+
+use serde::{Deserialize, Serialize};
+
+/// Self-trading prevention mode
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SelfTradingMode {
+    /// Reject the taker order
+    RejectTaker,
+    /// Cancel the maker order
+    CancelMaker,
+}
+
+impl SelfTradingMode {
+    /// Returns the mode as a string for API requests
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::RejectTaker => "reject_taker",
+            Self::CancelMaker => "cancel_maker",
+        }
+    }
+}
+
+impl std::fmt::Display for SelfTradingMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+/// Self-trading configuration
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SelfTradingConfig {
+    /// The self-trading prevention mode
+    pub mode: SelfTradingMode,
+    /// Whether the config extends to subaccounts
+    pub extended_to_subaccounts: bool,
+    /// Whether to block RFQ self-match prevention
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub block_rfq_self_match_prevention: Option<bool>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_self_trading_mode_serialization() {
+        let mode = SelfTradingMode::CancelMaker;
+        let json = serde_json::to_string(&mode).expect("Failed to serialize");
+        assert_eq!(json, "\"cancel_maker\"");
+    }
+
+    #[test]
+    fn test_self_trading_mode_deserialization() {
+        let json = "\"reject_taker\"";
+        let mode: SelfTradingMode = serde_json::from_str(json).expect("Failed to parse");
+        assert_eq!(mode, SelfTradingMode::RejectTaker);
+    }
+
+    #[test]
+    fn test_self_trading_config_deserialization() {
+        let json = r#"{
+            "mode": "cancel_maker",
+            "extended_to_subaccounts": true,
+            "block_rfq_self_match_prevention": false
+        }"#;
+
+        let config: SelfTradingConfig = serde_json::from_str(json).expect("Failed to parse");
+        assert_eq!(config.mode, SelfTradingMode::CancelMaker);
+        assert!(config.extended_to_subaccounts);
+        assert_eq!(config.block_rfq_self_match_prevention, Some(false));
+    }
+}

--- a/src/model/trading_products.rs
+++ b/src/model/trading_products.rs
@@ -1,0 +1,66 @@
+//! Trading products models for Deribit API
+//!
+//! This module contains types for trading product configuration.
+
+use serde::{Deserialize, Serialize};
+
+/// Trading product types that can be enabled/disabled
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TradingProduct {
+    /// Futures contracts
+    Futures,
+    /// Options contracts
+    Options,
+    /// Spot trading
+    Spots,
+    /// Future combo instruments
+    FutureCombos,
+    /// Option combo instruments
+    OptionCombos,
+}
+
+impl TradingProduct {
+    /// Returns the product as a string for API requests
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Futures => "futures",
+            Self::Options => "options",
+            Self::Spots => "spots",
+            Self::FutureCombos => "future_combos",
+            Self::OptionCombos => "option_combos",
+        }
+    }
+}
+
+impl std::fmt::Display for TradingProduct {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_trading_product_serialization() {
+        let product = TradingProduct::FutureCombos;
+        let json = serde_json::to_string(&product).expect("Failed to serialize");
+        assert_eq!(json, "\"future_combos\"");
+    }
+
+    #[test]
+    fn test_trading_product_deserialization() {
+        let json = "\"option_combos\"";
+        let product: TradingProduct = serde_json::from_str(json).expect("Failed to parse");
+        assert_eq!(product, TradingProduct::OptionCombos);
+    }
+
+    #[test]
+    fn test_trading_product_as_str() {
+        assert_eq!(TradingProduct::Spots.as_str(), "spots");
+        assert_eq!(TradingProduct::Options.as_str(), "options");
+    }
+}

--- a/src/model/user_lock.rs
+++ b/src/model/user_lock.rs
@@ -1,0 +1,60 @@
+//! User lock models for Deribit API
+//!
+//! This module contains types for user account locks.
+
+use serde::{Deserialize, Serialize};
+
+/// User account lock information
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UserLock {
+    /// Type of lock (e.g., "withdrawal", "trading")
+    #[serde(rename = "type")]
+    pub lock_type: String,
+    /// Currency affected by the lock, if applicable
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub currency: Option<String>,
+    /// Reason for the lock
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Timestamp when the lock was applied in milliseconds
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<u64>,
+    /// When the lock expires in milliseconds, if applicable
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expiration_timestamp: Option<u64>,
+    /// Whether the lock is currently active
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub locked: Option<bool>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_user_lock_deserialization() {
+        let json = r#"{
+            "type": "withdrawal",
+            "currency": "BTC",
+            "reason": "security_review",
+            "timestamp": 1550058362000,
+            "locked": true
+        }"#;
+
+        let lock: UserLock = serde_json::from_str(json).expect("Failed to parse");
+        assert_eq!(lock.lock_type, "withdrawal");
+        assert_eq!(lock.currency, Some("BTC".to_string()));
+        assert_eq!(lock.locked, Some(true));
+    }
+
+    #[test]
+    fn test_user_lock_minimal() {
+        let json = r#"{
+            "type": "trading"
+        }"#;
+
+        let lock: UserLock = serde_json::from_str(json).expect("Failed to parse");
+        assert_eq!(lock.lock_type, "trading");
+        assert!(lock.currency.is_none());
+    }
+}


### PR DESCRIPTION
## Description

Implements all remaining account management endpoints from issue #26.

## Changes

### Public Endpoints (1)
- `get_announcements`: Get platform announcements

### Private Endpoints (13)
- `get_access_log`: Account access history
- `get_user_locks`: User account locks
- `list_custody_accounts`: Custody accounts list
- `simulate_portfolio`: Portfolio margin simulation
- `pme_simulate`: PME margin simulation
- `change_margin_model`: Change account margin model
- `set_self_trading_config`: Self-trading prevention config
- `set_disabled_trading_products`: Disable trading products
- `get_new_announcements`: Unread announcements
- `set_announcement_as_read`: Mark announcement read
- `enable_affiliate_program`: Enable affiliate program
- `get_affiliate_program_info`: Affiliate program details
- `set_email_language` / `get_email_language`: Email preferences

### New Model Files (10)
- `access_log.rs`: Access log entries and response
- `affiliate.rs`: Affiliate program info
- `announcement.rs`: Platform announcements
- `custody.rs`: Custody accounts
- `email_settings.rs`: Email language preferences
- `margin_model.rs`: Margin model types
- `portfolio_simulation.rs`: Portfolio simulation request/response
- `self_trading.rs`: Self-trading configuration
- `trading_products.rs`: Trading product types
- `user_lock.rs`: User account locks

## Testing
- All 73 tests passing
- `make lint-fix` passes
- `make pre-push` passes

## Checklist
- [x] Code follows project style guidelines
- [x] All public items have documentation
- [x] No `.unwrap()` or `.expect()` in library code
- [x] Unit tests added for new models
- [x] All checks pass

Closes #26