### PR TITLE
M1 #28: Implement transfer endpoints

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -181,6 +181,13 @@ pub mod endpoints {
     pub const SUBMIT_TRANSFER_TO_SUBACCOUNT: &str = "/private/submit_transfer_to_subaccount";
     /// Submit transfer to user
     pub const SUBMIT_TRANSFER_TO_USER: &str = "/private/submit_transfer_to_user";
+    /// Get transfers list
+    pub const GET_TRANSFERS: &str = "/private/get_transfers";
+    /// Cancel a transfer by ID
+    pub const CANCEL_TRANSFER_BY_ID: &str = "/private/cancel_transfer_by_id";
+    /// Submit transfer between subaccounts
+    pub const SUBMIT_TRANSFER_BETWEEN_SUBACCOUNTS: &str =
+        "/private/submit_transfer_between_subaccounts";
     /// Move positions between subaccounts
     pub const MOVE_POSITIONS: &str = "/private/move_positions";
 

--- a/src/endpoints/private.rs
+++ b/src/endpoints/private.rs
@@ -19,6 +19,7 @@ use crate::model::response::order::{OrderInfoResponse, OrderResponse};
 use crate::model::response::other::{
     AccountSummaryResponse, SettlementsResponse, TransactionLogResponse, TransferResultResponse,
 };
+use crate::model::response::transfer::{InternalTransfer, TransfersResponse};
 use crate::model::response::position::MovePositionResult;
 use crate::model::response::subaccount::SubaccountDetails;
 use crate::model::response::trigger::TriggerOrderHistoryResponse;
@@ -955,6 +956,254 @@ impl DeribitHttpClient {
         api_response
             .result
             .ok_or_else(|| HttpError::InvalidResponse("No transfer result in response".to_string()))
+    }
+
+    /// Get transfers list
+    ///
+    /// Retrieves the user's internal transfers (between subaccounts or to other users).
+    ///
+    /// # Arguments
+    ///
+    /// * `currency` - Currency symbol (BTC, ETH, etc.)
+    /// * `count` - Number of transfers to retrieve (1-1000, default 10)
+    /// * `offset` - Offset for pagination (default 0)
+    ///
+    /// # Returns
+    ///
+    /// Returns a `TransfersResponse` containing the total count and list of transfers.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or the response is invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let transfers = client.get_transfers("BTC", Some(10), None).await?;
+    /// // tracing::info!("Found {} transfers", transfers.count);
+    /// ```
+    pub async fn get_transfers(
+        &self,
+        currency: &str,
+        count: Option<u32>,
+        offset: Option<u32>,
+    ) -> Result<TransfersResponse, HttpError> {
+        let mut query_params = vec![("currency".to_string(), currency.to_string())];
+
+        if let Some(c) = count {
+            query_params.push(("count".to_string(), c.to_string()));
+        }
+
+        if let Some(o) = offset {
+            query_params.push(("offset".to_string(), o.to_string()));
+        }
+
+        let query_string = query_params
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
+            .collect::<Vec<_>>()
+            .join("&");
+
+        let url = format!("{}{}?{}", self.base_url(), GET_TRANSFERS, query_string);
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get transfers failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<TransfersResponse> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No transfers data in response".to_string()))
+    }
+
+    /// Cancel a transfer by ID
+    ///
+    /// Cancels a pending internal transfer.
+    ///
+    /// # Arguments
+    ///
+    /// * `currency` - Currency symbol (BTC, ETH, etc.)
+    /// * `id` - Transfer ID to cancel
+    ///
+    /// # Returns
+    ///
+    /// Returns the cancelled `InternalTransfer`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the transfer cannot be cancelled or does not exist.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let transfer = client.cancel_transfer_by_id("BTC", 123).await?;
+    /// // tracing::info!("Cancelled transfer: {:?}", transfer.state);
+    /// ```
+    pub async fn cancel_transfer_by_id(
+        &self,
+        currency: &str,
+        id: i64,
+    ) -> Result<InternalTransfer, HttpError> {
+        let query_params = [
+            ("currency".to_string(), currency.to_string()),
+            ("id".to_string(), id.to_string()),
+        ];
+
+        let query_string = query_params
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
+            .collect::<Vec<_>>()
+            .join("&");
+
+        let url = format!(
+            "{}{}?{}",
+            self.base_url(),
+            CANCEL_TRANSFER_BY_ID,
+            query_string
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Cancel transfer failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<InternalTransfer> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No transfer data in response".to_string()))
+    }
+
+    /// Submit transfer between subaccounts
+    ///
+    /// Transfers funds between two subaccounts or between a subaccount and the main account.
+    ///
+    /// # Arguments
+    ///
+    /// * `currency` - Currency symbol (BTC, ETH, etc.)
+    /// * `amount` - Amount of funds to transfer
+    /// * `destination` - Destination subaccount ID
+    /// * `source` - Source subaccount ID (optional, defaults to requesting account)
+    ///
+    /// # Returns
+    ///
+    /// Returns the created `InternalTransfer`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the transfer fails or validation fails.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// let client = DeribitHttpClient::new();
+    /// // let transfer = client.submit_transfer_between_subaccounts("ETH", 1.5, 20, Some(10)).await?;
+    /// // tracing::info!("Transfer ID: {}", transfer.id);
+    /// ```
+    pub async fn submit_transfer_between_subaccounts(
+        &self,
+        currency: &str,
+        amount: f64,
+        destination: i64,
+        source: Option<i64>,
+    ) -> Result<InternalTransfer, HttpError> {
+        let mut query_params = vec![
+            ("currency".to_string(), currency.to_string()),
+            ("amount".to_string(), amount.to_string()),
+            ("destination".to_string(), destination.to_string()),
+        ];
+
+        if let Some(s) = source {
+            query_params.push(("source".to_string(), s.to_string()));
+        }
+
+        let query_string = query_params
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
+            .collect::<Vec<_>>()
+            .join("&");
+
+        let url = format!(
+            "{}{}?{}",
+            self.base_url(),
+            SUBMIT_TRANSFER_BETWEEN_SUBACCOUNTS,
+            query_string
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Submit transfer between subaccounts failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<InternalTransfer> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No transfer data in response".to_string()))
     }
 
     /// Place a buy order

--- a/src/model/response/mod.rs
+++ b/src/model/response/mod.rs
@@ -23,6 +23,8 @@ pub mod position;
 pub mod subaccount;
 /// Trade response models and types
 pub mod trade;
+/// Internal transfer response models
+pub mod transfer;
 /// Trigger order response models
 pub mod trigger;
 /// Wallet response models for address book operations
@@ -40,6 +42,7 @@ pub use other::*;
 pub use position::*;
 pub use subaccount::*;
 pub use trade::*;
+pub use transfer::*;
 pub use trigger::*;
 pub use wallet::*;
 pub use withdrawal::*;

--- a/src/model/response/transfer.rs
+++ b/src/model/response/transfer.rs
@@ -1,0 +1,212 @@
+/******************************************************************************
+   Author: Joaquín Béjar García
+   Email: jb@taunais.com
+   Date: 15/9/25
+******************************************************************************/
+//! Transfer response models for internal transfers between subaccounts.
+
+use serde::{Deserialize, Serialize};
+
+/// State of an internal transfer
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum InternalTransferState {
+    /// Transfer is prepared but not yet confirmed
+    #[default]
+    Prepared,
+    /// Transfer has been confirmed
+    Confirmed,
+    /// Transfer has been cancelled
+    Cancelled,
+    /// Transfer is waiting for admin approval
+    WaitingForAdmin,
+}
+
+/// Direction of an internal transfer
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum TransferDirection {
+    /// Outgoing payment
+    #[default]
+    Payment,
+    /// Incoming receipt
+    Income,
+}
+
+/// Type of internal transfer
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum InternalTransferType {
+    /// Transfer between subaccounts
+    #[default]
+    Subaccount,
+    /// Transfer to/from user
+    User,
+}
+
+/// Internal transfer information (between subaccounts or users)
+///
+/// This model represents transfers within the Deribit platform,
+/// not blockchain withdrawals/deposits.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct InternalTransfer {
+    /// Transfer ID
+    pub id: i64,
+    /// Currency being transferred (e.g., "BTC", "ETH")
+    pub currency: String,
+    /// Transfer amount
+    pub amount: f64,
+    /// Direction of the transfer (payment or income)
+    pub direction: TransferDirection,
+    /// The other party in the transfer (username or subaccount name)
+    pub other_side: String,
+    /// Current transfer state
+    pub state: InternalTransferState,
+    /// Type of transfer (subaccount or user)
+    #[serde(rename = "type")]
+    pub transfer_type: InternalTransferType,
+    /// Creation timestamp in milliseconds since Unix epoch
+    pub created_timestamp: i64,
+    /// Last update timestamp in milliseconds since Unix epoch
+    pub updated_timestamp: i64,
+}
+
+impl InternalTransfer {
+    /// Returns `true` if the transfer is confirmed
+    #[must_use]
+    pub fn is_confirmed(&self) -> bool {
+        self.state == InternalTransferState::Confirmed
+    }
+
+    /// Returns `true` if the transfer is cancelled
+    #[must_use]
+    pub fn is_cancelled(&self) -> bool {
+        self.state == InternalTransferState::Cancelled
+    }
+
+    /// Returns `true` if the transfer is pending (prepared or waiting for admin)
+    #[must_use]
+    pub fn is_pending(&self) -> bool {
+        matches!(
+            self.state,
+            InternalTransferState::Prepared | InternalTransferState::WaitingForAdmin
+        )
+    }
+
+    /// Returns `true` if this is an outgoing payment
+    #[must_use]
+    pub fn is_payment(&self) -> bool {
+        self.direction == TransferDirection::Payment
+    }
+
+    /// Returns `true` if this is an incoming transfer
+    #[must_use]
+    pub fn is_income(&self) -> bool {
+        self.direction == TransferDirection::Income
+    }
+}
+
+/// Response for get_transfers endpoint
+///
+/// Contains a paginated list of internal transfers with total count.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TransfersResponse {
+    /// Total number of transfers matching the query
+    pub count: u32,
+    /// List of transfer items
+    pub data: Vec<InternalTransfer>,
+}
+
+impl TransfersResponse {
+    /// Returns `true` if there are no transfers
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    /// Returns the number of transfers in this response
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_internal_transfer_deserialization() {
+        let json = r#"{
+            "id": 2,
+            "created_timestamp": 1550579457727,
+            "updated_timestamp": 1550579457727,
+            "currency": "BTC",
+            "amount": 0.2,
+            "direction": "payment",
+            "other_side": "new_user_1_1",
+            "state": "confirmed",
+            "type": "subaccount"
+        }"#;
+
+        let transfer: InternalTransfer = serde_json::from_str(json).unwrap();
+        assert_eq!(transfer.id, 2);
+        assert_eq!(transfer.currency, "BTC");
+        assert!((transfer.amount - 0.2).abs() < f64::EPSILON);
+        assert_eq!(transfer.direction, TransferDirection::Payment);
+        assert_eq!(transfer.other_side, "new_user_1_1");
+        assert_eq!(transfer.state, InternalTransferState::Confirmed);
+        assert_eq!(transfer.transfer_type, InternalTransferType::Subaccount);
+        assert!(transfer.is_confirmed());
+        assert!(transfer.is_payment());
+    }
+
+    #[test]
+    fn test_transfers_response_deserialization() {
+        let json = r#"{
+            "count": 1,
+            "data": [{
+                "id": 2,
+                "created_timestamp": 1550579457727,
+                "updated_timestamp": 1550579457727,
+                "currency": "BTC",
+                "amount": 0.2,
+                "direction": "payment",
+                "other_side": "new_user_1_1",
+                "state": "confirmed",
+                "type": "subaccount"
+            }]
+        }"#;
+
+        let response: TransfersResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.count, 1);
+        assert_eq!(response.len(), 1);
+        assert!(!response.is_empty());
+    }
+
+    #[test]
+    fn test_transfer_state_helpers() {
+        let mut transfer = InternalTransfer {
+            id: 1,
+            currency: "BTC".to_string(),
+            amount: 1.0,
+            direction: TransferDirection::Payment,
+            other_side: "test".to_string(),
+            state: InternalTransferState::Prepared,
+            transfer_type: InternalTransferType::Subaccount,
+            created_timestamp: 0,
+            updated_timestamp: 0,
+        };
+
+        assert!(transfer.is_pending());
+        assert!(!transfer.is_confirmed());
+        assert!(!transfer.is_cancelled());
+
+        transfer.state = InternalTransferState::Confirmed;
+        assert!(!transfer.is_pending());
+        assert!(transfer.is_confirmed());
+
+        transfer.state = InternalTransferState::Cancelled;
+        assert!(transfer.is_cancelled());
+    }
+}

--- a/tests/integration/wallet/transfers.rs
+++ b/tests/integration/wallet/transfers.rs
@@ -358,4 +358,254 @@ mod withdrawal_tests {
         info!("Transfer parameter validation test completed successfully");
         Ok(())
     }
+
+    // =========================================================================
+    // Get Transfers Tests (Issue #28)
+    // =========================================================================
+
+    #[tokio::test]
+    #[ignore = "Requires authentication"]
+    #[serial_test::serial]
+    async fn test_get_transfers_success() -> Result<(), Box<dyn std::error::Error>> {
+        check_env_file()?;
+
+        let client = DeribitHttpClient::new();
+
+        // Get transfers for BTC
+        let result = client.get_transfers("BTC", Some(10), None).await;
+
+        match result {
+            Ok(transfers) => {
+                info!("Got {} transfers (total: {})", transfers.len(), transfers.count);
+                for transfer in &transfers.data {
+                    debug!(
+                        "Transfer ID: {}, Amount: {} {}, Direction: {:?}, State: {:?}",
+                        transfer.id,
+                        transfer.amount,
+                        transfer.currency,
+                        transfer.direction,
+                        transfer.state
+                    );
+                }
+            }
+            Err(e) => {
+                warn!("Get transfers failed (may be expected): {:?}", e);
+            }
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires authentication"]
+    #[serial_test::serial]
+    async fn test_get_transfers_with_pagination() -> Result<(), Box<dyn std::error::Error>> {
+        check_env_file()?;
+
+        let client = DeribitHttpClient::new();
+
+        // Get first page
+        let page1 = client.get_transfers("BTC", Some(5), Some(0)).await;
+        // Get second page
+        let page2 = client.get_transfers("BTC", Some(5), Some(5)).await;
+
+        match (page1, page2) {
+            (Ok(p1), Ok(p2)) => {
+                info!("Page 1: {} transfers, Page 2: {} transfers", p1.len(), p2.len());
+                assert!(
+                    p1.count == p2.count,
+                    "Total count should be consistent across pages"
+                );
+            }
+            (Err(e1), _) => {
+                warn!("Page 1 failed: {:?}", e1);
+            }
+            (_, Err(e2)) => {
+                warn!("Page 2 failed: {:?}", e2);
+            }
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires authentication"]
+    #[serial_test::serial]
+    async fn test_get_transfers_multiple_currencies() -> Result<(), Box<dyn std::error::Error>> {
+        check_env_file()?;
+
+        let client = DeribitHttpClient::new();
+
+        let currencies = ["BTC", "ETH", "USDC"];
+
+        for currency in currencies {
+            let result = client.get_transfers(currency, Some(5), None).await;
+
+            match result {
+                Ok(transfers) => {
+                    info!(
+                        "{}: {} transfers (total: {})",
+                        currency,
+                        transfers.len(),
+                        transfers.count
+                    );
+                }
+                Err(e) => {
+                    warn!("Get transfers for {} failed: {:?}", currency, e);
+                }
+            }
+
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+
+        Ok(())
+    }
+
+    // =========================================================================
+    // Cancel Transfer Tests (Issue #28)
+    // =========================================================================
+
+    #[tokio::test]
+    #[ignore = "Requires authentication and active transfer"]
+    #[serial_test::serial]
+    async fn test_cancel_transfer_by_id() -> Result<(), Box<dyn std::error::Error>> {
+        check_env_file()?;
+
+        let client = DeribitHttpClient::new();
+
+        // This test requires an actual pending transfer to cancel
+        // Using a non-existent ID to test error handling
+        let result = client.cancel_transfer_by_id("BTC", 999999).await;
+
+        match result {
+            Ok(transfer) => {
+                info!("Transfer cancelled: {:?}", transfer);
+                assert!(transfer.is_cancelled(), "Transfer should be cancelled");
+            }
+            Err(e) => {
+                warn!("Cancel transfer failed (expected for non-existent ID): {:?}", e);
+            }
+        }
+
+        Ok(())
+    }
+
+    // =========================================================================
+    // Submit Transfer Between Subaccounts Tests (Issue #28)
+    // =========================================================================
+
+    #[tokio::test]
+    #[ignore = "Requires authentication and subaccounts"]
+    #[serial_test::serial]
+    async fn test_submit_transfer_between_subaccounts() -> Result<(), Box<dyn std::error::Error>> {
+        check_env_file()?;
+
+        let client = DeribitHttpClient::new();
+
+        // This test requires actual subaccounts to exist
+        // Using test parameters that will likely fail but test API structure
+        let result = client
+            .submit_transfer_between_subaccounts("BTC", 0.00001, 1, None)
+            .await;
+
+        match result {
+            Ok(transfer) => {
+                info!("Transfer submitted: {:?}", transfer);
+                assert_eq!(transfer.currency, "BTC");
+                assert!(transfer.is_confirmed() || transfer.is_pending());
+            }
+            Err(e) => {
+                warn!(
+                    "Submit transfer between subaccounts failed (expected): {:?}",
+                    e
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires authentication and subaccounts"]
+    #[serial_test::serial]
+    async fn test_submit_transfer_between_subaccounts_with_source(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        check_env_file()?;
+
+        let client = DeribitHttpClient::new();
+
+        // Test with explicit source subaccount
+        let result = client
+            .submit_transfer_between_subaccounts("ETH", 0.001, 20, Some(10))
+            .await;
+
+        match result {
+            Ok(transfer) => {
+                info!("Transfer submitted with source: {:?}", transfer);
+                assert_eq!(transfer.currency, "ETH");
+            }
+            Err(e) => {
+                warn!(
+                    "Submit transfer with source failed (expected): {:?}",
+                    e
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires authentication"]
+    #[serial_test::serial]
+    async fn test_transfer_workflow() -> Result<(), Box<dyn std::error::Error>> {
+        check_env_file()?;
+
+        let client = DeribitHttpClient::new();
+
+        info!("Testing complete transfer workflow");
+
+        // Step 1: Get initial transfers
+        let initial_transfers = client.get_transfers("BTC", Some(10), None).await;
+        let initial_count = initial_transfers.map(|t| t.count).unwrap_or(0);
+        info!("Initial transfer count: {}", initial_count);
+
+        // Step 2: Attempt a transfer (will likely fail without proper setup)
+        let transfer_result = client
+            .submit_transfer_between_subaccounts("BTC", 0.00001, 1, None)
+            .await;
+
+        match transfer_result {
+            Ok(transfer) => {
+                info!("Transfer created: ID={}", transfer.id);
+
+                // Step 3: Verify transfer appears in list
+                let updated_transfers = client.get_transfers("BTC", Some(10), None).await;
+                if let Ok(transfers) = updated_transfers {
+                    info!("Updated transfer count: {}", transfers.count);
+                }
+
+                // Step 4: Attempt to cancel if transfer is pending
+                if transfer.is_pending() {
+                    let cancel_result = client
+                        .cancel_transfer_by_id("BTC", transfer.id)
+                        .await;
+                    match cancel_result {
+                        Ok(cancelled) => {
+                            info!("Transfer cancelled: {:?}", cancelled.state);
+                        }
+                        Err(e) => {
+                            warn!("Cancel failed: {:?}", e);
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                warn!("Transfer workflow test: transfer creation failed (expected): {:?}", e);
+            }
+        }
+
+        info!("Transfer workflow test completed");
+        Ok(())
+    }
 }

--- a/tests/unit/private_endpoints_tests.rs
+++ b/tests/unit/private_endpoints_tests.rs
@@ -2070,3 +2070,297 @@ async fn test_toggle_notifications_from_subaccount_error() {
     mock.assert_async().await;
     assert!(result.is_err());
 }
+
+// =========================================================================
+// Transfer Endpoints Tests (Issue #28)
+// =========================================================================
+
+#[tokio::test]
+async fn test_get_transfers_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": {
+            "count": 1,
+            "data": [{
+                "id": 2,
+                "created_timestamp": 1550579457727_i64,
+                "updated_timestamp": 1550579457727_i64,
+                "currency": "BTC",
+                "amount": 0.2,
+                "direction": "payment",
+                "other_side": "new_user_1_1",
+                "state": "confirmed",
+                "type": "subaccount"
+            }]
+        },
+        "id": 1
+    });
+
+    let mock = server
+        .mock("GET", "/api/v2/private/get_transfers?currency=BTC")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.get_transfers("BTC", None, None).await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let transfers = result.unwrap();
+    assert_eq!(transfers.count, 1);
+    assert_eq!(transfers.len(), 1);
+    assert!(!transfers.is_empty());
+    assert_eq!(transfers.data[0].id, 2);
+    assert_eq!(transfers.data[0].currency, "BTC");
+    assert!((transfers.data[0].amount - 0.2).abs() < f64::EPSILON);
+    assert_eq!(transfers.data[0].other_side, "new_user_1_1");
+}
+
+#[tokio::test]
+async fn test_get_transfers_with_pagination() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": {
+            "count": 0,
+            "data": []
+        },
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            "/api/v2/private/get_transfers?currency=ETH&count=5&offset=10",
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.get_transfers("ETH", Some(5), Some(10)).await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let transfers = result.unwrap();
+    assert_eq!(transfers.count, 0);
+    assert!(transfers.is_empty());
+}
+
+#[tokio::test]
+async fn test_get_transfers_error() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock = server
+        .mock("GET", "/api/v2/private/get_transfers?currency=INVALID")
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"jsonrpc": "2.0", "error": {"code": 10001, "message": "invalid_currency"}, "id": 1}"#,
+        )
+        .create_async()
+        .await;
+
+    let result = client.get_transfers("INVALID", None, None).await;
+
+    mock.assert_async().await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_cancel_transfer_by_id_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": {
+            "id": 123,
+            "created_timestamp": 1550579457727_i64,
+            "updated_timestamp": 1550579457800_i64,
+            "currency": "BTC",
+            "amount": 0.5,
+            "direction": "payment",
+            "other_side": "subaccount_1",
+            "state": "cancelled",
+            "type": "subaccount"
+        },
+        "id": 1
+    });
+
+    let mock = server
+        .mock("GET", "/api/v2/private/cancel_transfer_by_id?currency=BTC&id=123")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.cancel_transfer_by_id("BTC", 123).await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let transfer = result.unwrap();
+    assert_eq!(transfer.id, 123);
+    assert!(transfer.is_cancelled());
+}
+
+#[tokio::test]
+async fn test_cancel_transfer_by_id_error() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock = server
+        .mock("GET", "/api/v2/private/cancel_transfer_by_id?currency=BTC&id=999")
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"jsonrpc": "2.0", "error": {"code": 10003, "message": "transfer_not_found"}, "id": 1}"#,
+        )
+        .create_async()
+        .await;
+
+    let result = client.cancel_transfer_by_id("BTC", 999).await;
+
+    mock.assert_async().await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_submit_transfer_between_subaccounts_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": {
+            "id": 456,
+            "created_timestamp": 1550579457727_i64,
+            "updated_timestamp": 1550579457727_i64,
+            "currency": "ETH",
+            "amount": 12.1234,
+            "direction": "payment",
+            "other_side": "subaccount_20",
+            "state": "confirmed",
+            "type": "subaccount"
+        },
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            "/api/v2/private/submit_transfer_between_subaccounts?currency=ETH&amount=12.1234&destination=20",
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client
+        .submit_transfer_between_subaccounts("ETH", 12.1234, 20, None)
+        .await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let transfer = result.unwrap();
+    assert_eq!(transfer.id, 456);
+    assert_eq!(transfer.currency, "ETH");
+    assert!((transfer.amount - 12.1234).abs() < f64::EPSILON);
+    assert!(transfer.is_confirmed());
+    assert!(transfer.is_payment());
+}
+
+#[tokio::test]
+async fn test_submit_transfer_between_subaccounts_with_source() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": {
+            "id": 789,
+            "created_timestamp": 1550579457727_i64,
+            "updated_timestamp": 1550579457727_i64,
+            "currency": "BTC",
+            "amount": 1.0,
+            "direction": "payment",
+            "other_side": "subaccount_20",
+            "state": "confirmed",
+            "type": "subaccount"
+        },
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            "/api/v2/private/submit_transfer_between_subaccounts?currency=BTC&amount=1&destination=20&source=10",
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client
+        .submit_transfer_between_subaccounts("BTC", 1.0, 20, Some(10))
+        .await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let transfer = result.unwrap();
+    assert_eq!(transfer.id, 789);
+}
+
+#[tokio::test]
+async fn test_submit_transfer_between_subaccounts_error() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock = server
+        .mock(
+            "GET",
+            "/api/v2/private/submit_transfer_between_subaccounts?currency=BTC&amount=1000000&destination=999",
+        )
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"jsonrpc": "2.0", "error": {"code": 10004, "message": "insufficient_funds"}, "id": 1}"#,
+        )
+        .create_async()
+        .await;
+
+    let result = client
+        .submit_transfer_between_subaccounts("BTC", 1000000.0, 999, None)
+        .await;
+
+    mock.assert_async().await;
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary

Implements three transfer-related wallet endpoints: `get_transfers`, `cancel_transfer_by_id`, and `submit_transfer_between_subaccounts` for managing internal transfers between subaccounts.

## Changes

- Added endpoint constants in `constants.rs`
- Created `InternalTransfer`, `TransfersResponse` models with enums for state, direction, and type
- Implemented 3 async client methods in `private.rs`
- Added 8 unit tests with HTTP mocking
- Added 7 integration tests (ignored by default, require auth)

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] Benchmark tests added/updated (if applicable)
- [x] Manual testing performed (`cargo test --all-features`)

## Checklist

- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] No `.unwrap()`, `.expect()`, or panics in library code
- [x] HTTP error handling implemented
- [x] Minimal dependencies — no unnecessary crates added

Closes #28
