### PR TITLE
M1 #31: Implement combo books endpoints

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -95,6 +95,20 @@ pub mod endpoints {
     /// Get index chart data
     pub const GET_INDEX_CHART_DATA: &str = "/public/get_index_chart_data";
 
+    // Public combo books endpoints
+    /// Get combo details by ID
+    pub const GET_COMBO_DETAILS: &str = "/public/get_combo_details";
+    /// Get list of combo IDs by currency and state
+    pub const GET_COMBO_IDS: &str = "/public/get_combo_ids";
+    /// Get all active combos by currency
+    pub const GET_COMBOS: &str = "/public/get_combos";
+
+    // Private combo books endpoints
+    /// Create or verify a combo book
+    pub const CREATE_COMBO: &str = "/private/create_combo";
+    /// Get individual leg prices for a combo structure
+    pub const GET_LEG_PRICES: &str = "/private/get_leg_prices";
+
     // Private trading endpoints
     /// Place a buy order
     pub const BUY: &str = "/private/buy";

--- a/src/endpoints/private.rs
+++ b/src/endpoints/private.rs
@@ -7314,4 +7314,159 @@ impl DeribitHttpClient {
             .result
             .ok_or_else(|| HttpError::InvalidResponse("No signature in response".to_string()))
     }
+
+    // ========================================================================
+    // Combo Books Endpoints
+    // ========================================================================
+
+    /// Create a combo book
+    ///
+    /// Verifies and creates a combo book or returns an existing combo
+    /// matching the given trades.
+    ///
+    /// # Arguments
+    ///
+    /// * `trades` - List of trades used to create a combo
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or the response is invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use deribit_http::DeribitHttpClient;
+    /// use deribit_http::model::ComboTrade;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = DeribitHttpClient::new();
+    /// let trades = vec![
+    ///     ComboTrade::buy("BTC-29APR22-37500-C", Some(1.0)),
+    ///     ComboTrade::sell("BTC-29APR22-37500-P", Some(1.0)),
+    /// ];
+    /// // let combo = client.create_combo(&trades).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create_combo(
+        &self,
+        trades: &[crate::model::ComboTrade],
+    ) -> Result<crate::model::Combo, HttpError> {
+        let trades_json = serde_json::to_string(trades).map_err(|e| {
+            HttpError::InvalidResponse(format!("Failed to serialize trades: {}", e))
+        })?;
+
+        let url = format!(
+            "{}{}?trades={}",
+            self.base_url(),
+            CREATE_COMBO,
+            urlencoding::encode(&trades_json)
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Create combo failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<crate::model::Combo> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No combo data in response".to_string()))
+    }
+
+    /// Get leg prices for a combo structure
+    ///
+    /// Returns individual leg prices for a given combo structure based on
+    /// an aggregated price of the strategy and the mark prices of the
+    /// individual legs.
+    ///
+    /// # Arguments
+    ///
+    /// * `legs` - List of legs for which the prices will be calculated
+    /// * `price` - Price for the whole leg structure
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or the response is invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use deribit_http::DeribitHttpClient;
+    /// use deribit_http::model::LegInput;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = DeribitHttpClient::new();
+    /// let legs = vec![
+    ///     LegInput::buy("BTC-1NOV24-67000-C", 2.0),
+    ///     LegInput::sell("BTC-1NOV24-66000-C", 2.0),
+    /// ];
+    /// // let prices = client.get_leg_prices(&legs, 0.6).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_leg_prices(
+        &self,
+        legs: &[crate::model::LegInput],
+        price: f64,
+    ) -> Result<crate::model::LegPricesResponse, HttpError> {
+        let legs_json = serde_json::to_string(legs)
+            .map_err(|e| HttpError::InvalidResponse(format!("Failed to serialize legs: {}", e)))?;
+
+        let url = format!(
+            "{}{}?legs={}&price={}",
+            self.base_url(),
+            GET_LEG_PRICES,
+            urlencoding::encode(&legs_json),
+            price
+        );
+
+        let response = self.make_authenticated_request(&url).await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get leg prices failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<crate::model::LegPricesResponse> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No leg prices in response".to_string()))
+    }
 }

--- a/src/endpoints/public.rs
+++ b/src/endpoints/public.rs
@@ -2761,4 +2761,226 @@ impl DeribitHttpClient {
             .result
             .ok_or_else(|| HttpError::InvalidResponse("No announcements in response".to_string()))
     }
+
+    // ========================================================================
+    // Combo Books Endpoints
+    // ========================================================================
+
+    /// Get combo details by ID
+    ///
+    /// Retrieves information about a specific combo instrument.
+    /// This is a public endpoint that doesn't require authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `combo_id` - The combo identifier (e.g., "BTC-FS-29APR22_PERP")
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or the response is invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = DeribitHttpClient::new();
+    /// let combo = client.get_combo_details("BTC-FS-29APR22_PERP").await?;
+    /// println!("Combo {} has {} legs", combo.id, combo.legs.len());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_combo_details(
+        &self,
+        combo_id: &str,
+    ) -> Result<crate::model::Combo, HttpError> {
+        let url = format!(
+            "{}{}?combo_id={}",
+            self.base_url(),
+            GET_COMBO_DETAILS,
+            urlencoding::encode(combo_id)
+        );
+
+        let response = self
+            .http_client()
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| HttpError::NetworkError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get combo details failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<crate::model::Combo> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No combo data in response".to_string()))
+    }
+
+    /// Get combo IDs by currency
+    ///
+    /// Retrieves the list of available combo IDs for the specified currency.
+    /// This is a public endpoint that doesn't require authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `currency` - The currency symbol (BTC, ETH, USDC, USDT, EURR)
+    /// * `state` - Optional combo state filter (rfq, active, inactive)
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or the response is invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = DeribitHttpClient::new();
+    /// let combo_ids = client.get_combo_ids("BTC", Some("active")).await?;
+    /// println!("Found {} active combos", combo_ids.len());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_combo_ids(
+        &self,
+        currency: &str,
+        state: Option<&str>,
+    ) -> Result<Vec<String>, HttpError> {
+        let mut url = format!(
+            "{}{}?currency={}",
+            self.base_url(),
+            GET_COMBO_IDS,
+            urlencoding::encode(currency)
+        );
+
+        if let Some(s) = state {
+            url.push_str(&format!("&state={}", urlencoding::encode(s)));
+        }
+
+        let response = self
+            .http_client()
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| HttpError::NetworkError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get combo IDs failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<Vec<String>> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No combo IDs in response".to_string()))
+    }
+
+    /// Get all active combos by currency
+    ///
+    /// Retrieves information about all active combo instruments for a currency.
+    /// This is a public endpoint that doesn't require authentication.
+    ///
+    /// # Arguments
+    ///
+    /// * `currency` - The currency symbol (BTC, ETH, USDC, USDT, EURR, or "any" for all)
+    ///
+    /// # Errors
+    ///
+    /// Returns `HttpError` if the request fails or the response is invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use deribit_http::DeribitHttpClient;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = DeribitHttpClient::new();
+    /// let combos = client.get_combos("BTC").await?;
+    /// for combo in combos {
+    ///     println!("Combo: {} ({:?})", combo.id, combo.state);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_combos(&self, currency: &str) -> Result<Vec<crate::model::Combo>, HttpError> {
+        let url = format!(
+            "{}{}?currency={}",
+            self.base_url(),
+            GET_COMBOS,
+            urlencoding::encode(currency)
+        );
+
+        let response = self
+            .http_client()
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| HttpError::NetworkError(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(HttpError::RequestFailed(format!(
+                "Get combos failed: {}",
+                error_text
+            )));
+        }
+
+        let api_response: ApiResponse<Vec<crate::model::Combo>> = response
+            .json()
+            .await
+            .map_err(|e| HttpError::InvalidResponse(e.to_string()))?;
+
+        if let Some(error) = api_response.error {
+            return Err(HttpError::RequestFailed(format!(
+                "API error: {} - {}",
+                error.code, error.message
+            )));
+        }
+
+        api_response
+            .result
+            .ok_or_else(|| HttpError::InvalidResponse("No combos data in response".to_string()))
+    }
 }

--- a/src/model/combo.rs
+++ b/src/model/combo.rs
@@ -1,0 +1,376 @@
+/******************************************************************************
+   Author: Joaquín Béjar García
+   Email: jb@taunais.com
+   Date: 7/3/26
+******************************************************************************/
+//! Combo books models for Deribit API
+//!
+//! This module provides types for combo instrument operations including
+//! creating combos and calculating leg prices.
+
+use serde::{Deserialize, Serialize};
+
+/// Combo state enumeration
+///
+/// Represents the current state of a combo instrument.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[derive(Default)]
+pub enum ComboState {
+    /// Request for quote state
+    #[default]
+    Rfq,
+    /// Active combo available for trading
+    Active,
+    /// Inactive combo not available for trading
+    Inactive,
+}
+
+impl std::fmt::Display for ComboState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ComboState::Rfq => write!(f, "rfq"),
+            ComboState::Active => write!(f, "active"),
+            ComboState::Inactive => write!(f, "inactive"),
+        }
+    }
+}
+
+/// A leg within a combo instrument
+///
+/// Represents a single leg of a combo, consisting of an instrument
+/// and an amount multiplier.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ComboLeg {
+    /// Unique instrument identifier for this leg
+    pub instrument_name: String,
+    /// Size multiplier of the leg. A negative value indicates that trades
+    /// on this leg are in the opposite direction to the combo trades.
+    pub amount: i64,
+}
+
+impl ComboLeg {
+    /// Creates a new combo leg
+    ///
+    /// # Arguments
+    ///
+    /// * `instrument_name` - The instrument identifier
+    /// * `amount` - The size multiplier (can be negative for opposite direction)
+    #[must_use]
+    pub fn new(instrument_name: impl Into<String>, amount: i64) -> Self {
+        Self {
+            instrument_name: instrument_name.into(),
+            amount,
+        }
+    }
+
+    /// Returns true if this leg represents the opposite direction
+    #[must_use]
+    pub fn is_opposite_direction(&self) -> bool {
+        self.amount < 0
+    }
+}
+
+/// Combo instrument information
+///
+/// Contains full details about a combo instrument including its legs,
+/// state, and timestamps.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Combo {
+    /// Unique combo identifier (e.g., "BTC-FS-29APR22_PERP")
+    pub id: String,
+    /// Numeric instrument ID
+    pub instrument_id: u64,
+    /// Current state of the combo
+    pub state: ComboState,
+    /// Timestamp of the last state change in milliseconds since Unix epoch
+    pub state_timestamp: u64,
+    /// Timestamp when the combo was created in milliseconds since Unix epoch
+    pub creation_timestamp: u64,
+    /// List of legs that make up this combo
+    pub legs: Vec<ComboLeg>,
+}
+
+impl Combo {
+    /// Returns true if the combo is currently active for trading
+    #[must_use]
+    pub fn is_active(&self) -> bool {
+        self.state == ComboState::Active
+    }
+
+    /// Returns true if the combo is in RFQ state
+    #[must_use]
+    pub fn is_rfq(&self) -> bool {
+        self.state == ComboState::Rfq
+    }
+
+    /// Returns the number of legs in this combo
+    #[must_use]
+    pub fn leg_count(&self) -> usize {
+        self.legs.len()
+    }
+}
+
+/// Trade input for creating a combo
+///
+/// Used as input to the `create_combo` endpoint to specify
+/// the instruments and directions for each leg.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ComboTrade {
+    /// Instrument name for this trade
+    pub instrument_name: String,
+    /// Trade amount (optional). For perpetual and inverse futures the amount
+    /// is in USD units. For options and linear futures it is the underlying
+    /// base currency coin.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub amount: Option<f64>,
+    /// Direction of trade from the maker perspective: "buy" or "sell"
+    pub direction: String,
+}
+
+impl ComboTrade {
+    /// Creates a new combo trade
+    ///
+    /// # Arguments
+    ///
+    /// * `instrument_name` - The instrument identifier
+    /// * `direction` - Trade direction ("buy" or "sell")
+    /// * `amount` - Optional trade amount
+    #[must_use]
+    pub fn new(
+        instrument_name: impl Into<String>,
+        direction: impl Into<String>,
+        amount: Option<f64>,
+    ) -> Self {
+        Self {
+            instrument_name: instrument_name.into(),
+            direction: direction.into(),
+            amount,
+        }
+    }
+
+    /// Creates a buy trade
+    #[must_use]
+    pub fn buy(instrument_name: impl Into<String>, amount: Option<f64>) -> Self {
+        Self::new(instrument_name, "buy", amount)
+    }
+
+    /// Creates a sell trade
+    #[must_use]
+    pub fn sell(instrument_name: impl Into<String>, amount: Option<f64>) -> Self {
+        Self::new(instrument_name, "sell", amount)
+    }
+}
+
+/// Leg input for `get_leg_prices` endpoint
+///
+/// Specifies the parameters for calculating individual leg prices.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LegInput {
+    /// Instrument name for this leg
+    pub instrument_name: String,
+    /// Trade amount. For perpetual and inverse futures the amount is in USD
+    /// units. For options and linear futures it is the underlying base
+    /// currency coin.
+    pub amount: f64,
+    /// Direction of the leg: "buy" or "sell"
+    pub direction: String,
+}
+
+impl LegInput {
+    /// Creates a new leg input
+    ///
+    /// # Arguments
+    ///
+    /// * `instrument_name` - The instrument identifier
+    /// * `amount` - Trade amount
+    /// * `direction` - Trade direction ("buy" or "sell")
+    #[must_use]
+    pub fn new(
+        instrument_name: impl Into<String>,
+        amount: f64,
+        direction: impl Into<String>,
+    ) -> Self {
+        Self {
+            instrument_name: instrument_name.into(),
+            amount,
+            direction: direction.into(),
+        }
+    }
+
+    /// Creates a buy leg input
+    #[must_use]
+    pub fn buy(instrument_name: impl Into<String>, amount: f64) -> Self {
+        Self::new(instrument_name, amount, "buy")
+    }
+
+    /// Creates a sell leg input
+    #[must_use]
+    pub fn sell(instrument_name: impl Into<String>, amount: f64) -> Self {
+        Self::new(instrument_name, amount, "sell")
+    }
+}
+
+/// Individual leg price in response
+///
+/// Contains the calculated price and ratio for a single leg.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LegPrice {
+    /// Instrument name for this leg
+    pub instrument_name: String,
+    /// Direction: "buy" or "sell"
+    pub direction: String,
+    /// Calculated price for this leg
+    pub price: f64,
+    /// Ratio of amount between legs
+    pub ratio: i64,
+}
+
+/// Response from `get_leg_prices` endpoint
+///
+/// Contains the calculated leg prices for a combo structure.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LegPricesResponse {
+    /// This value multiplied by the ratio of a leg gives trade size on that leg
+    pub amount: f64,
+    /// List of leg prices
+    pub legs: Vec<LegPrice>,
+}
+
+impl LegPricesResponse {
+    /// Returns the number of legs in the response
+    #[must_use]
+    pub fn leg_count(&self) -> usize {
+        self.legs.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_combo_state_serialization() {
+        assert_eq!(
+            serde_json::to_string(&ComboState::Active).unwrap(),
+            "\"active\""
+        );
+        assert_eq!(serde_json::to_string(&ComboState::Rfq).unwrap(), "\"rfq\"");
+        assert_eq!(
+            serde_json::to_string(&ComboState::Inactive).unwrap(),
+            "\"inactive\""
+        );
+    }
+
+    #[test]
+    fn test_combo_state_deserialization() {
+        assert_eq!(
+            serde_json::from_str::<ComboState>("\"active\"").unwrap(),
+            ComboState::Active
+        );
+        assert_eq!(
+            serde_json::from_str::<ComboState>("\"rfq\"").unwrap(),
+            ComboState::Rfq
+        );
+        assert_eq!(
+            serde_json::from_str::<ComboState>("\"inactive\"").unwrap(),
+            ComboState::Inactive
+        );
+    }
+
+    #[test]
+    fn test_combo_leg_new() {
+        let leg = ComboLeg::new("BTC-PERPETUAL", -1);
+        assert_eq!(leg.instrument_name, "BTC-PERPETUAL");
+        assert_eq!(leg.amount, -1);
+        assert!(leg.is_opposite_direction());
+    }
+
+    #[test]
+    fn test_combo_leg_positive_amount() {
+        let leg = ComboLeg::new("BTC-29APR22", 1);
+        assert!(!leg.is_opposite_direction());
+    }
+
+    #[test]
+    fn test_combo_trade_buy() {
+        let trade = ComboTrade::buy("BTC-29APR22-37500-C", Some(1.0));
+        assert_eq!(trade.instrument_name, "BTC-29APR22-37500-C");
+        assert_eq!(trade.direction, "buy");
+        assert_eq!(trade.amount, Some(1.0));
+    }
+
+    #[test]
+    fn test_combo_trade_sell() {
+        let trade = ComboTrade::sell("BTC-29APR22-37500-P", None);
+        assert_eq!(trade.direction, "sell");
+        assert!(trade.amount.is_none());
+    }
+
+    #[test]
+    fn test_leg_input_new() {
+        let leg = LegInput::new("BTC-1NOV24-67000-C", 2.0, "buy");
+        assert_eq!(leg.instrument_name, "BTC-1NOV24-67000-C");
+        assert_eq!(leg.amount, 2.0);
+        assert_eq!(leg.direction, "buy");
+    }
+
+    #[test]
+    fn test_combo_deserialization() {
+        let json = r#"{
+            "state_timestamp": 1650960943922,
+            "state": "rfq",
+            "legs": [
+                {"instrument_name": "BTC-29APR22-37500-C", "amount": 1},
+                {"instrument_name": "BTC-29APR22-37500-P", "amount": -1}
+            ],
+            "id": "BTC-REV-29APR22-37500",
+            "instrument_id": 52,
+            "creation_timestamp": 1650960943000
+        }"#;
+
+        let combo: Combo = serde_json::from_str(json).unwrap();
+        assert_eq!(combo.id, "BTC-REV-29APR22-37500");
+        assert_eq!(combo.instrument_id, 52);
+        assert_eq!(combo.state, ComboState::Rfq);
+        assert!(combo.is_rfq());
+        assert!(!combo.is_active());
+        assert_eq!(combo.leg_count(), 2);
+        assert_eq!(combo.legs[0].instrument_name, "BTC-29APR22-37500-C");
+        assert_eq!(combo.legs[0].amount, 1);
+        assert_eq!(combo.legs[1].amount, -1);
+    }
+
+    #[test]
+    fn test_leg_prices_response_deserialization() {
+        let json = r#"{
+            "legs": [
+                {"ratio": 1, "instrument_name": "BTC-1NOV24-67000-C", "price": 0.6001, "direction": "buy"},
+                {"ratio": 1, "instrument_name": "BTC-1NOV24-66000-C", "price": 0.0001, "direction": "sell"}
+            ],
+            "amount": 2
+        }"#;
+
+        let response: LegPricesResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.amount, 2.0);
+        assert_eq!(response.leg_count(), 2);
+        assert_eq!(response.legs[0].price, 0.6001);
+        assert_eq!(response.legs[1].direction, "sell");
+    }
+
+    #[test]
+    fn test_combo_trade_serialization() {
+        let trade = ComboTrade::new("BTC-29APR22-37500-C", "buy", Some(1.0));
+        let json = serde_json::to_string(&trade).unwrap();
+        assert!(json.contains("\"instrument_name\":\"BTC-29APR22-37500-C\""));
+        assert!(json.contains("\"direction\":\"buy\""));
+        assert!(json.contains("\"amount\":1.0"));
+    }
+
+    #[test]
+    fn test_combo_trade_without_amount() {
+        let trade = ComboTrade::new("BTC-29APR22-37500-C", "buy", None);
+        let json = serde_json::to_string(&trade).unwrap();
+        assert!(!json.contains("amount"));
+    }
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -17,6 +17,8 @@ pub mod beneficiary;
 pub mod block_trade;
 /// Order book models
 pub mod book;
+/// Combo books models for multi-leg instruments
+pub mod combo;
 /// Currency and expiration models
 pub mod currency;
 /// Custody account models
@@ -86,6 +88,7 @@ pub use api_key::*;
 pub use beneficiary::*;
 pub use block_trade::*;
 pub use book::*;
+pub use combo::*;
 pub use currency::*;
 pub use custody::*;
 pub use deposit::*;

--- a/tests/unit/combo_tests.rs
+++ b/tests/unit/combo_tests.rs
@@ -1,0 +1,431 @@
+/******************************************************************************
+   Author: Joaquín Béjar García
+   Email: jb@taunais.com
+   Date: 7/3/26
+******************************************************************************/
+//! Unit tests for combo books endpoints
+
+use deribit_http::{DeribitHttpClient, HttpConfig};
+use serde_json::json;
+use url::Url;
+
+/// Helper function to create a test client with mock server
+fn create_test_client(server: &mockito::Server) -> DeribitHttpClient {
+    let mut server_url = server.url();
+    if server_url.ends_with('/') {
+        server_url.pop();
+    }
+    let config = HttpConfig {
+        base_url: Url::parse(&server_url).expect("Invalid mock server URL"),
+        ..Default::default()
+    };
+    DeribitHttpClient::with_config(config)
+}
+
+/// Helper function for private endpoint tests
+fn create_auth_test_client(server: &mockito::ServerGuard) -> DeribitHttpClient {
+    unsafe {
+        std::env::set_var("DERIBIT_CLIENT_ID", "test_client_id");
+        std::env::set_var("DERIBIT_CLIENT_SECRET", "test_client_secret");
+        std::env::set_var("DERIBIT_TESTNET", "true");
+    }
+
+    let config = HttpConfig {
+        base_url: Url::parse(&format!("{}/api/v2", server.url())).unwrap(),
+        ..Default::default()
+    };
+
+    DeribitHttpClient::with_config(config)
+}
+
+async fn create_auth_mock(server: &mut mockito::Server) -> mockito::Mock {
+    server
+        .mock("GET", "/api/v2/public/auth?grant_type=client_credentials&client_id=test_client_id&client_secret=test_client_secret")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "access_token": "test_access_token",
+                "expires_in": 3600,
+                "refresh_token": "test_refresh_token",
+                "scope": "read",
+                "state": "",
+                "token_type": "bearer"
+            }
+        }"#)
+        .create_async()
+        .await
+}
+
+// =========================================================================
+// Public Combo Endpoints Tests
+// =========================================================================
+
+#[tokio::test]
+async fn test_get_combo_details_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": {
+            "state_timestamp": 1650620605150_u64,
+            "state": "active",
+            "legs": [
+                {"instrument_name": "BTC-PERPETUAL", "amount": -1},
+                {"instrument_name": "BTC-29APR22", "amount": 1}
+            ],
+            "id": "BTC-FS-29APR22_PERP",
+            "instrument_id": 27,
+            "creation_timestamp": 1650620575000_u64
+        },
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(r"//public/get_combo_details\?combo_id=.*".to_string()),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.get_combo_details("BTC-FS-29APR22_PERP").await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let combo = result.unwrap();
+    assert_eq!(combo.id, "BTC-FS-29APR22_PERP");
+    assert_eq!(combo.instrument_id, 27);
+    assert!(combo.is_active());
+    assert_eq!(combo.leg_count(), 2);
+    assert_eq!(combo.legs[0].instrument_name, "BTC-PERPETUAL");
+    assert_eq!(combo.legs[0].amount, -1);
+}
+
+#[tokio::test]
+async fn test_get_combo_details_error() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let mock = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(r"//public/get_combo_details\?combo_id=.*".to_string()),
+        )
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"jsonrpc": "2.0", "error": {"code": 11050, "message": "combo_not_found"}, "id": 1}"#)
+        .create_async()
+        .await;
+
+    let result = client.get_combo_details("INVALID-COMBO").await;
+
+    mock.assert_async().await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_get_combo_ids_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": [
+            "BTC-CS-29APR22-39300_39600",
+            "BTC-FS-29APR22_PERP"
+        ],
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(r"//public/get_combo_ids\?currency=BTC.*".to_string()),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.get_combo_ids("BTC", Some("active")).await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let combo_ids = result.unwrap();
+    assert_eq!(combo_ids.len(), 2);
+    assert_eq!(combo_ids[0], "BTC-CS-29APR22-39300_39600");
+    assert_eq!(combo_ids[1], "BTC-FS-29APR22_PERP");
+}
+
+#[tokio::test]
+async fn test_get_combo_ids_empty() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": [],
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(r"//public/get_combo_ids\?currency=ETH.*".to_string()),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.get_combo_ids("ETH", None).await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let combo_ids = result.unwrap();
+    assert!(combo_ids.is_empty());
+}
+
+#[tokio::test]
+async fn test_get_combos_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": [
+            {
+                "state_timestamp": 1650636265101_u64,
+                "state": "active",
+                "legs": [
+                    {"instrument_name": "BTC-29APR22-39300-C", "amount": 1},
+                    {"instrument_name": "BTC-29APR22-39600-C", "amount": -1}
+                ],
+                "id": "BTC-CS-29APR22-39300_39600",
+                "instrument_id": 28,
+                "creation_timestamp": 1650636235000_u64
+            },
+            {
+                "state_timestamp": 1650620605150_u64,
+                "state": "active",
+                "legs": [
+                    {"instrument_name": "BTC-PERPETUAL", "amount": -1},
+                    {"instrument_name": "BTC-29APR22", "amount": 1}
+                ],
+                "id": "BTC-FS-29APR22_PERP",
+                "instrument_id": 27,
+                "creation_timestamp": 1650620575000_u64
+            }
+        ],
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(r"//public/get_combos\?currency=BTC.*".to_string()),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let result = client.get_combos("BTC").await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let combos = result.unwrap();
+    assert_eq!(combos.len(), 2);
+    assert_eq!(combos[0].id, "BTC-CS-29APR22-39300_39600");
+    assert_eq!(combos[1].id, "BTC-FS-29APR22_PERP");
+}
+
+#[tokio::test]
+async fn test_get_combos_error() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_test_client(&server);
+
+    let mock = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(r"//public/get_combos\?currency=.*".to_string()),
+        )
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"jsonrpc": "2.0", "error": {"code": 10001, "message": "invalid_currency"}, "id": 1}"#)
+        .create_async()
+        .await;
+
+    let result = client.get_combos("INVALID").await;
+
+    mock.assert_async().await;
+    assert!(result.is_err());
+}
+
+// =========================================================================
+// Private Combo Endpoints Tests
+// =========================================================================
+
+#[tokio::test]
+async fn test_create_combo_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_auth_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": {
+            "state_timestamp": 1650960943922_u64,
+            "state": "rfq",
+            "legs": [
+                {"instrument_name": "BTC-29APR22-37500-C", "amount": 1},
+                {"instrument_name": "BTC-29APR22-37500-P", "amount": -1}
+            ],
+            "id": "BTC-REV-29APR22-37500",
+            "instrument_id": 52,
+            "creation_timestamp": 1650960943000_u64
+        },
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(r"/api/v2/private/create_combo\?trades=.*".to_string()),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let trades = vec![
+        deribit_http::model::ComboTrade::buy("BTC-29APR22-37500-C", Some(1.0)),
+        deribit_http::model::ComboTrade::sell("BTC-29APR22-37500-P", Some(1.0)),
+    ];
+    let result = client.create_combo(&trades).await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let combo = result.unwrap();
+    assert_eq!(combo.id, "BTC-REV-29APR22-37500");
+    assert_eq!(combo.instrument_id, 52);
+    assert!(combo.is_rfq());
+    assert_eq!(combo.leg_count(), 2);
+}
+
+#[tokio::test]
+async fn test_create_combo_error() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_auth_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(r"/api/v2/private/create_combo\?trades=.*".to_string()),
+        )
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"jsonrpc": "2.0", "error": {"code": 11051, "message": "invalid_combo_structure"}, "id": 1}"#)
+        .create_async()
+        .await;
+
+    let trades = vec![deribit_http::model::ComboTrade::buy(
+        "INVALID-INSTRUMENT",
+        Some(1.0),
+    )];
+    let result = client.create_combo(&trades).await;
+
+    mock.assert_async().await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_get_leg_prices_success() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_auth_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "result": {
+            "legs": [
+                {"ratio": 1, "instrument_name": "BTC-1NOV24-67000-C", "price": 0.6001, "direction": "buy"},
+                {"ratio": 1, "instrument_name": "BTC-1NOV24-66000-C", "price": 0.0001, "direction": "sell"}
+            ],
+            "amount": 2.0
+        },
+        "id": 1
+    });
+
+    let mock = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(
+                r"/api/v2/private/get_leg_prices\?legs=.*&price=.*".to_string(),
+            ),
+        )
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create_async()
+        .await;
+
+    let legs = vec![
+        deribit_http::model::LegInput::buy("BTC-1NOV24-67000-C", 2.0),
+        deribit_http::model::LegInput::sell("BTC-1NOV24-66000-C", 2.0),
+    ];
+    let result = client.get_leg_prices(&legs, 0.6).await;
+
+    mock.assert_async().await;
+    assert!(result.is_ok());
+    let response = result.unwrap();
+    assert_eq!(response.amount, 2.0);
+    assert_eq!(response.leg_count(), 2);
+    assert_eq!(response.legs[0].instrument_name, "BTC-1NOV24-67000-C");
+    assert_eq!(response.legs[0].price, 0.6001);
+    assert_eq!(response.legs[0].direction, "buy");
+    assert_eq!(response.legs[1].direction, "sell");
+}
+
+#[tokio::test]
+async fn test_get_leg_prices_error() {
+    let mut server = mockito::Server::new_async().await;
+    let client = create_auth_test_client(&server);
+
+    let _auth_mock = create_auth_mock(&mut server).await;
+
+    let mock = server
+        .mock(
+            "GET",
+            mockito::Matcher::Regex(r"/api/v2/private/get_leg_prices\?legs=.*&price=.*".to_string()),
+        )
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"jsonrpc": "2.0", "error": {"code": 11052, "message": "invalid_leg_structure"}, "id": 1}"#)
+        .create_async()
+        .await;
+
+    let legs = vec![deribit_http::model::LegInput::buy(
+        "INVALID-INSTRUMENT",
+        2.0,
+    )];
+    let result = client.get_leg_prices(&legs, 0.6).await;
+
+    mock.assert_async().await;
+    assert!(result.is_err());
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -10,6 +10,7 @@ pub mod block_trade_tests;
 pub mod book_tests;
 pub mod builder_tests;
 pub mod client_tests;
+pub mod combo_tests;
 pub mod connection_tests;
 pub mod currency_tests;
 pub mod funding_tests;


### PR DESCRIPTION
## Summary

Implements 5 combo books endpoints (3 public, 2 private) for creating and querying combo instruments in the Deribit HTTP client.

## Changes

- Added 5 endpoint constants to `src/constants.rs`
- Created `src/model/combo.rs` with combo types:
  - `ComboState` enum (rfq, active, inactive)
  - `ComboLeg`, `Combo` structs
  - `ComboTrade`, `LegInput`, `LegPrice`, `LegPricesResponse`
- Implemented 3 public methods:
  - `get_combo_details()` - Get combo info by ID
  - `get_combo_ids()` - List combo IDs by currency/state
  - `get_combos()` - List all active combos by currency
- Implemented 2 private methods:
  - `create_combo()` - Create/verify a combo book
  - `get_leg_prices()` - Calculate individual leg prices
- Added 21 unit tests (11 model + 10 endpoint tests)

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] Benchmark tests added/updated (if applicable)
- [x] Manual testing performed (`cargo test --all-features`)

## Checklist

- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] No `.unwrap()`, `.expect()`, or panics in library code
- [x] HTTP error handling implemented
- [x] Minimal dependencies — no unnecessary crates added

Closes #31
